### PR TITLE
Fix auth integration and add role guards

### DIFF
--- a/src/app/modules/auth/services/auth-http/auth-http.service.ts
+++ b/src/app/modules/auth/services/auth-http/auth-http.service.ts
@@ -20,9 +20,9 @@ export class AuthHTTPService {
       password,
     });
   }
-getProfile(): Observable<UserModel> {
-  return this.http.get<UserModel>(`${this.API_URL}/auth/profile`);
-}
+  getProfile(): Observable<UserModel> {
+    return this.http.get<UserModel>(`${environment.apiUrl}/auth/profile`);
+  }
 
   getUserByToken(token: string): Observable<UserModel> {
     const headers = new HttpHeaders().set('Authorization', `Bearer ${token}`);

--- a/src/app/modules/auth/services/auth-http/index.ts
+++ b/src/app/modules/auth/services/auth-http/index.ts
@@ -1,7 +1,7 @@
 // #fake-start#
-export { AuthHTTPService } from './fake/auth-fake-http.service'; // You have to comment this, when your real back-end is done
+// export { AuthHTTPService } from './fake/auth-fake-http.service'; // You have to comment this, when your real back-end is done
 // #fake-end#
 
 // #real-start#
-// export { AuthHTTPService } from './auth-http.service'; // You have to uncomment this, when your real back-end is done
+export { AuthHTTPService } from './auth-http.service'; // You have to uncomment this, when your real back-end is done
 // #real-end#

--- a/src/app/modules/auth/services/role.guard.ts
+++ b/src/app/modules/auth/services/role.guard.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class RoleGuard implements CanActivate {
+  constructor(private authService: AuthService, private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    const allowedRoles = route.data['roles'] as string[] | string | undefined;
+    const currentUser = this.authService.currentUserValue;
+
+    if (!currentUser) {
+      this.router.navigate(['/auth/login'], { queryParams: { returnUrl: state.url } });
+      return false;
+    }
+
+    if (!allowedRoles) {
+      return true;
+    }
+
+    const roles = Array.isArray(allowedRoles) ? allowedRoles : [allowedRoles];
+    if (roles.includes(currentUser.role)) {
+      return true;
+    }
+
+    this.router.navigate(['/']);
+    return false;
+  }
+}

--- a/src/app/modules/orders/orders-routing.module.ts
+++ b/src/app/modules/orders/orders-routing.module.ts
@@ -2,15 +2,20 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { OrderListComponent } from './components/order-list/order-list.component';
 import { OrderDetailComponent } from './components/order-detail/order-detail.component';
+import { RoleGuard } from '../auth/services/role.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: OrderListComponent,
+    canActivate: [RoleGuard],
+    data: { roles: ['Admin'] }
   },
   {
     path: 'detail/:id',
     component: OrderDetailComponent,
+    canActivate: [RoleGuard],
+    data: { roles: ['Admin'] }
   }
 ];
 @NgModule({

--- a/src/app/modules/support-tickets/support-tickets-routing.module.ts
+++ b/src/app/modules/support-tickets/support-tickets-routing.module.ts
@@ -4,11 +4,27 @@ import { SupportTicketsComponent } from './support-tickets.component';
 import { TicketListComponent } from './components/ticket-list/ticket-list.component';
 import { TicketCreateComponent } from './components/ticket-create/ticket-create.component';
 import { TicketDetailComponent } from './components/ticket-detail/ticket-detail.component';
+import { RoleGuard } from '../auth/services/role.guard';
 
 const routes: Routes = [
-  { path: '', component: TicketListComponent },           // /support-tickets
-  { path: 'create', component: TicketCreateComponent },   // /support-tickets/create
-  { path: ':id', component: TicketDetailComponent },      // /support-tickets/:id
+  {
+    path: '',
+    component: TicketListComponent,
+    canActivate: [RoleGuard],
+    data: { roles: ['Support'] }
+  },           // /support-tickets
+  {
+    path: 'create',
+    component: TicketCreateComponent,
+    canActivate: [RoleGuard],
+    data: { roles: ['Support'] }
+  },   // /support-tickets/create
+  {
+    path: ':id',
+    component: TicketDetailComponent,
+    canActivate: [RoleGuard],
+    data: { roles: ['Support'] }
+  },      // /support-tickets/:id
   
 ];
 


### PR DESCRIPTION
## Summary
- switch to real AuthHTTPService
- correct profile request URL
- add RoleGuard for role-based access
- protect orders and support ticket modules by role

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-unused-vars' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cdb92030c832684a196435bd44b0c