### PR TITLE
Add mailbox module skeleton

### DIFF
--- a/src/app/modules/mailbox/components/inbox/inbox.component.html
+++ b/src/app/modules/mailbox/components/inbox/inbox.component.html
@@ -1,0 +1,29 @@
+<div class="container-fluid px-0">
+  <div class="row">
+    <div class="col-12" *ngFor="let msg of messages">
+      <div class="card mb-3 shadow-sm">
+        <div class="card-body d-flex align-items-center">
+          <div class="symbol symbol-circle symbol-40px me-4">
+            <img *ngIf="msg.channel === 'WhatsApp'" src="assets/media/brands/whatsapp.svg" alt="WhatsApp" class="h-40px" />
+            <img *ngIf="msg.channel === 'Instagram'" src="assets/media/brands/instagram.svg" alt="Instagram" class="h-40px" />
+          </div>
+          <div class="flex-grow-1">
+            <div class="d-flex justify-content-between align-items-center mb-1">
+              <div class="fw-semibold">{{ msg.senderName }}</div>
+              <small class="text-muted">{{ msg.timestamp | date:'short' }}</small>
+            </div>
+            <div class="text-muted">{{ msg.message }}</div>
+          </div>
+          <span class="badge ms-3"
+            [ngClass]="{
+              'badge-light-warning': msg.status === 'Pending Reply',
+              'badge-light-success': msg.status === 'Answered',
+              'badge-light-danger': msg.status === 'Spam'
+            }">
+            {{ msg.status }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/modules/mailbox/components/inbox/inbox.component.scss
+++ b/src/app/modules/mailbox/components/inbox/inbox.component.scss
@@ -1,0 +1,1 @@
+/* Placeholder for custom styles */

--- a/src/app/modules/mailbox/components/inbox/inbox.component.ts
+++ b/src/app/modules/mailbox/components/inbox/inbox.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+import { MessageService } from '../../services/message.service';
+import { Message } from '../../models/message.model';
+
+@Component({
+  selector: 'app-mailbox-inbox',
+  templateUrl: './inbox.component.html',
+  styleUrls: ['./inbox.component.scss']
+})
+export class InboxComponent implements OnInit {
+  messages: Message[] = [];
+
+  constructor(private messageService: MessageService) {}
+
+  ngOnInit(): void {
+    this.messages = this.messageService.getMessages();
+  }
+}

--- a/src/app/modules/mailbox/components/message-detail/message-detail.component.html
+++ b/src/app/modules/mailbox/components/message-detail/message-detail.component.html
@@ -1,0 +1,1 @@
+<p>message detail works!</p>

--- a/src/app/modules/mailbox/components/message-detail/message-detail.component.scss
+++ b/src/app/modules/mailbox/components/message-detail/message-detail.component.scss
@@ -1,0 +1,1 @@
+/* Placeholder for detail styles */

--- a/src/app/modules/mailbox/components/message-detail/message-detail.component.ts
+++ b/src/app/modules/mailbox/components/message-detail/message-detail.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-mailbox-message-detail',
+  templateUrl: './message-detail.component.html',
+  styleUrls: ['./message-detail.component.scss']
+})
+export class MessageDetailComponent {}

--- a/src/app/modules/mailbox/components/pending-replies/pending-replies.component.html
+++ b/src/app/modules/mailbox/components/pending-replies/pending-replies.component.html
@@ -1,0 +1,24 @@
+<div class="container-fluid px-0">
+  <div class="row">
+    <div class="col-12" *ngFor="let msg of messages">
+      <div class="card mb-3 shadow-sm">
+        <div class="card-body d-flex align-items-center">
+          <div class="symbol symbol-circle symbol-40px me-4">
+            <img *ngIf="msg.channel === 'WhatsApp'" src="assets/media/brands/whatsapp.svg" alt="WhatsApp" class="h-40px" />
+            <img *ngIf="msg.channel === 'Instagram'" src="assets/media/brands/instagram.svg" alt="Instagram" class="h-40px" />
+          </div>
+          <div class="flex-grow-1">
+            <div class="d-flex justify-content-between align-items-center mb-1">
+              <div class="fw-semibold">{{ msg.senderName }}</div>
+              <small class="text-muted">{{ msg.timestamp | date:'short' }}</small>
+            </div>
+            <div class="text-muted">{{ msg.message }}</div>
+          </div>
+          <span class="badge ms-3" [ngClass]="'badge-light-warning'">
+            {{ msg.status }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/modules/mailbox/components/pending-replies/pending-replies.component.scss
+++ b/src/app/modules/mailbox/components/pending-replies/pending-replies.component.scss
@@ -1,0 +1,1 @@
+/* Placeholder for custom styles */

--- a/src/app/modules/mailbox/components/pending-replies/pending-replies.component.ts
+++ b/src/app/modules/mailbox/components/pending-replies/pending-replies.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+import { MessageService } from '../../services/message.service';
+import { Message } from '../../models/message.model';
+
+@Component({
+  selector: 'app-mailbox-pending-replies',
+  templateUrl: './pending-replies.component.html',
+  styleUrls: ['./pending-replies.component.scss']
+})
+export class PendingRepliesComponent implements OnInit {
+  messages: Message[] = [];
+
+  constructor(private messageService: MessageService) {}
+
+  ngOnInit(): void {
+    this.messages = this.messageService.getPendingReplies();
+  }
+}

--- a/src/app/modules/mailbox/mailbox-routing.module.ts
+++ b/src/app/modules/mailbox/mailbox-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { InboxComponent } from './components/inbox/inbox.component';
+import { PendingRepliesComponent } from './components/pending-replies/pending-replies.component';
+
+const routes: Routes = [
+  { path: 'inbox', component: InboxComponent },
+  { path: 'pending-replies', component: PendingRepliesComponent },
+  { path: '', redirectTo: 'inbox', pathMatch: 'full' }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class MailboxRoutingModule { }

--- a/src/app/modules/mailbox/mailbox.module.ts
+++ b/src/app/modules/mailbox/mailbox.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MailboxRoutingModule } from './mailbox-routing.module';
+import { InboxComponent } from './components/inbox/inbox.component';
+import { PendingRepliesComponent } from './components/pending-replies/pending-replies.component';
+import { MessageDetailComponent } from './components/message-detail/message-detail.component';
+
+@NgModule({
+  declarations: [
+    InboxComponent,
+    PendingRepliesComponent,
+    MessageDetailComponent
+  ],
+  imports: [
+    CommonModule,
+    RouterModule,
+    MailboxRoutingModule
+  ]
+})
+export class MailboxModule { }

--- a/src/app/modules/mailbox/models/message.model.ts
+++ b/src/app/modules/mailbox/models/message.model.ts
@@ -1,0 +1,8 @@
+export interface Message {
+  id: number;
+  channel: string;
+  senderName: string;
+  message: string;
+  timestamp: string;
+  status: 'Pending Reply' | 'Answered' | 'Spam';
+}

--- a/src/app/modules/mailbox/services/message.service.ts
+++ b/src/app/modules/mailbox/services/message.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { Message } from '../models/message.model';
+
+@Injectable({ providedIn: 'root' })
+export class MessageService {
+  private messages: Message[] = [
+    {
+      id: 1,
+      channel: 'WhatsApp',
+      senderName: 'Ahmet Yılmaz',
+      message: 'Hi, I’d like to ask about the product.',
+      timestamp: '2025-08-01T13:15:00Z',
+      status: 'Pending Reply'
+    },
+    {
+      id: 2,
+      channel: 'Instagram',
+      senderName: 'elif.celik',
+      message: 'When will my order arrive?',
+      timestamp: '2025-08-01T12:50:00Z',
+      status: 'Answered'
+    }
+  ];
+
+  getMessages(): Message[] {
+    return this.messages;
+  }
+
+  getPendingReplies(): Message[] {
+    return this.messages.filter(m => m.status === 'Pending Reply');
+  }
+}

--- a/src/app/pages/routing.ts
+++ b/src/app/pages/routing.ts
@@ -73,11 +73,16 @@ const Routing: Routes = [
     loadChildren: () =>
       import('../modules/orders/orders.module').then((m) => m.OrdersModule),
   },
-{
-  path: 'support-tickets',
-  loadChildren: () =>
-    import('../modules/support-tickets/support-tickets.module').then((m) => m.SupportTicketsModule),
-},
+  {
+    path: 'mailbox',
+    loadChildren: () =>
+      import('../modules/mailbox/mailbox.module').then((m) => m.MailboxModule),
+  },
+  {
+    path: 'support-tickets',
+    loadChildren: () =>
+      import('../modules/support-tickets/support-tickets.module').then((m) => m.SupportTicketsModule),
+  },
   {
     path: '',
     redirectTo: '/dashboard',


### PR DESCRIPTION
## Summary
- add Mailbox module with Inbox and Pending Replies components
- define Message model and mock message service
- wire mailbox routes into page routing

## Testing
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-unused-vars' was not found)*
- `npm test --silent` *(fails: Cannot find module 'karma.conf.js')*

------
https://chatgpt.com/codex/tasks/task_e_688ceae6c7388326b672446ae4eb53fa