### PR TITLE
Integrate backend Support Ticket API

### DIFF
--- a/src/app/modules/support-tickets/components/ticket-create/ticket-create.component.ts
+++ b/src/app/modules/support-tickets/components/ticket-create/ticket-create.component.ts
@@ -143,10 +143,15 @@ export class TicketCreateComponent implements OnInit {
     }
 
     this.ticketService.create(ticketData, this.attachedFiles).subscribe({
-      next: () => {
+      next: (created) => {
         this.loading = false;
         alert('✅ Destek talebi başarıyla oluşturuldu.');
-        this.router.navigate(['/support-tickets']);
+        const id = created.id;
+        if (id) {
+          this.router.navigate(['/support-tickets', id]);
+        } else {
+          this.router.navigate(['/support-tickets']);
+        }
       },
       error: (err) => {
         this.loading = false;

--- a/src/app/modules/support-tickets/components/ticket-detail/ticket-detail.component.html
+++ b/src/app/modules/support-tickets/components/ticket-detail/ticket-detail.component.html
@@ -110,22 +110,29 @@
   </div>
 
   <!-- Güncelle -->
-  <div class="card mb-5 mt-5">
+  <div class="card mb-5 mt-5" *ngIf="isAdmin || isSupport">
     <div class="card-header">
       <h5 class="card-title">Güncelle</h5>
     </div>
     <div class="card-body">
       <div class="row mb-3">
-        <div class="col-md-6">
+        <div class="col-md-4">
           <label class="form-label">Durum</label>
           <select class="form-select" [(ngModel)]="selectedStatus">
             <option *ngFor="let s of statusOptions" [ngValue]="s.id">{{ s.label }}</option>
           </select>
         </div>
-        <div class="col-md-6">
+        <div class="col-md-4">
           <label class="form-label">Öncelik</label>
           <select class="form-select" [(ngModel)]="selectedPriority">
             <option *ngFor="let p of priorityOptions" [ngValue]="p.id">{{ p.label }}</option>
+          </select>
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">Atanan Kullanıcı</label>
+          <select class="form-select" [(ngModel)]="selectedUserId">
+            <option [ngValue]="null">Seçiniz</option>
+            <option *ngFor="let u of assignableUsers" [ngValue]="u.id">{{ u.fullName }}</option>
           </select>
         </div>
       </div>
@@ -134,7 +141,7 @@
   </div>
 
   <!-- Not Ekle -->
-  <div class="card mb-5">
+  <div class="card mb-5" *ngIf="isAdmin || isSupport">
     <div class="card-header">
       <h5 class="card-title">Not Ekle</h5>
     </div>

--- a/src/app/modules/support-tickets/components/ticket-list/ticket-list.component.html
+++ b/src/app/modules/support-tickets/components/ticket-list/ticket-list.component.html
@@ -1,6 +1,7 @@
 <div class="container-fluid px-0">
   <!-- Kategori filtre butonları -->
   <div class="mb-4 d-flex flex-wrap gap-2">
+    <input type="text" class="form-control form-control-sm w-auto" placeholder="Ara" [(ngModel)]="search" (ngModelChange)="onSearchChange()" />
     <button class="btn btn-sm"
             [ngClass]="{ 'btn-primary': selectedCategory === null, 'btn-light': selectedCategory !== null }"
             (click)="filterByCategory(null)">
@@ -28,17 +29,11 @@
       <option [ngValue]="2">Cevap Bekleniyor</option>
       <option [ngValue]="3">Kapandı</option>
     </select>
-    <select class="form-select form-select-sm w-auto" [(ngModel)]="selectedPriority" (ngModelChange)="onPriorityChange($event)">
-      <option [ngValue]="null">Öncelik</option>
-      <option [ngValue]="1">Yüksek</option>
-      <option [ngValue]="2">Orta</option>
-      <option [ngValue]="3">Düşük</option>
-    </select>
   </div>
 
   <!-- Kart listesi -->
   <div class="row">
-    <div class="col-12 mb-4" *ngFor="let ticket of filteredTickets">
+    <div class="col-12 mb-4" *ngFor="let ticket of tickets">
       <a [routerLink]="['/support-tickets', ticket.id]" class="text-decoration-none text-dark">
         <div class="card shadow-sm hoverable w-100">
           <div class="card-body d-flex align-items-center">
@@ -102,7 +97,10 @@
   </div>
 
   <!-- Boş liste -->
-  <div *ngIf="!loading && filteredTickets.length === 0" class="text-center text-muted mt-5">
-    Seçilen kategoriye ait destek talebi bulunmamaktadır.
+  <div *ngIf="!loading && tickets.length === 0" class="text-center text-muted mt-5">
+    Destek talebi bulunamadı.
+  </div>
+  <div class="text-center my-5" *ngIf="hasMore && !loading">
+    <button class="btn btn-light-primary" (click)="loadTickets()">Daha Fazla</button>
   </div>
 </div>

--- a/src/app/modules/support-tickets/components/ticket-list/ticket-list.component.ts
+++ b/src/app/modules/support-tickets/components/ticket-list/ticket-list.component.ts
@@ -1,49 +1,92 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { SupportTicketService } from '../../services/support-ticket.service';
 import { SupportTicketDto } from '../../models/support-ticket.model';
 import { AuthService } from 'src/app/modules/auth';
+import { SupportTicketQuery } from '../../models/support-ticket-query.model';
 
 @Component({
   selector: 'app-ticket-list',
   templateUrl: './ticket-list.component.html'
 })
-export class TicketListComponent implements OnInit {
+export class TicketListComponent implements OnInit, OnDestroy {
   tickets: SupportTicketDto[] = [];
-  filteredTickets: SupportTicketDto[] = [];
-  loading = true;
+  loading = false;
+  page = 1;
+  pageSize = 10;
+  hasMore = true;
+  search = '';
   selectedCategory: number | null = null;
   selectedStatus: number | null = null;
-  selectedPriority: number | null = null;
+
+  private subs: Subscription[] = [];
 
   constructor(
     private ticketService: SupportTicketService,
-    private auth: AuthService
+    private auth: AuthService,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
-    const currentUser = this.auth.getAuthFromLocalStorage();
-    const isAdmin = currentUser?.role === 'Admin';
-    const userId = currentUser?.id;
-    
-this.ticketService.getAll().subscribe({
-  next: (res) => {
-    const currentUser = this.auth.getAuthFromLocalStorage();
-    const isAdmin = currentUser?.role === 'Admin';
-    const userId = currentUser?.id;
-
-    this.tickets = isAdmin
-      ? res
-      : res.filter(t => t.assignedToUserId === userId); // sadece kendine atanmışları gör
-
-    this.filteredTickets = this.tickets;
-    this.loading = false;
-  },
-  error: (err) => {
-    console.error('Listeleme hatası:', err);
-    this.loading = false;
+    this.loadTickets(true);
   }
-});
 
+  loadTickets(reset = false): void {
+    if (reset) {
+      this.page = 1;
+      this.tickets = [];
+      this.hasMore = true;
+    }
+    if (!this.hasMore || this.loading) return;
+
+    this.loading = true;
+    const currentUser = this.auth.getAuthFromLocalStorage();
+    const isAdmin = currentUser?.role === 'Admin';
+
+    const query: SupportTicketQuery = {
+      pageNumber: this.page,
+      pageSize: this.pageSize,
+      category: this.selectedCategory ?? undefined,
+      status: this.selectedStatus ?? undefined,
+      search: this.search || undefined
+    };
+
+    const sub = this.ticketService.list(query).subscribe({
+      next: (res) => {
+        let items = res.items;
+        if (!isAdmin) {
+          items = items.filter(t => t.assignedToUserId === currentUser?.id);
+        }
+        this.tickets.push(...items);
+        this.hasMore = items.length === this.pageSize;
+        this.page++;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      }
+    });
+
+    this.subs.push(sub);
+  }
+
+  onSearchChange(): void {
+    this.loadTickets(true);
+  }
+
+  filterByCategory(category: number | null): void {
+    this.selectedCategory = category;
+    this.loadTickets(true);
+  }
+
+  onStatusChange(status: number | null): void {
+    this.selectedStatus = status;
+    this.loadTickets(true);
+  }
+
+  ngOnDestroy(): void {
+    this.subs.forEach(s => s.unsubscribe());
   }
 
   // Atanan kişinin veya oluşturucunun baş harfleri
@@ -94,27 +137,5 @@ this.ticketService.getAll().subscribe({
     return tags ? tags.split(',').map(tag => tag.trim()) : [];
   }
 
-  // Kategoriye göre filtrele
-  filterTickets(): void {
-    this.filteredTickets = this.tickets.filter(t =>
-      (this.selectedCategory === null || t.category === this.selectedCategory) &&
-      (this.selectedStatus === null || t.status === this.selectedStatus) &&
-      (this.selectedPriority === null || t.priority === this.selectedPriority)
-    );
-  }
-
-  filterByCategory(category: number | null): void {
-    this.selectedCategory = category;
-    this.filterTickets();
-  }
-
-  onStatusChange(status: number | null): void {
-    this.selectedStatus = status;
-    this.filterTickets();
-  }
-
-  onPriorityChange(priority: number | null): void {
-    this.selectedPriority = priority;
-    this.filterTickets();
-  }
+  // deprecated local filtering methods removed
 }

--- a/src/app/modules/support-tickets/models/paged-result.model.ts
+++ b/src/app/modules/support-tickets/models/paged-result.model.ts
@@ -1,0 +1,4 @@
+export interface PagedResult<T> {
+  items: T[];
+  totalCount: number;
+}

--- a/src/app/modules/support-tickets/models/support-ticket-query.model.ts
+++ b/src/app/modules/support-tickets/models/support-ticket-query.model.ts
@@ -1,0 +1,7 @@
+export interface SupportTicketQuery {
+  pageNumber?: number;
+  pageSize?: number;
+  category?: number;
+  status?: number;
+  search?: string;
+}

--- a/src/app/modules/support-tickets/services/support-ticket.service.ts
+++ b/src/app/modules/support-tickets/services/support-ticket.service.ts
@@ -1,8 +1,10 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { SupportTicketCreateDto, SupportTicketDto } from '../models/support-ticket.model';
+import { PagedResult } from '../models/paged-result.model';
+import { SupportTicketQuery } from '../models/support-ticket-query.model';
 
 @Injectable({
   providedIn: 'root'
@@ -12,9 +14,15 @@ export class SupportTicketService {
 
   constructor(private http: HttpClient) {}
 
-  // 🟢 Tüm destek taleplerini getir
-  getAll(): Observable<SupportTicketDto[]> {
-    return this.http.get<SupportTicketDto[]>(this.baseUrl);
+  // 🟢 Destek taleplerini filtre ve sayfalama ile getir
+  list(query: SupportTicketQuery): Observable<PagedResult<SupportTicketDto>> {
+    let params = new HttpParams();
+    Object.entries(query).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        params = params.set(key, value as any);
+      }
+    });
+    return this.http.get<PagedResult<SupportTicketDto>>(this.baseUrl, { params });
   }
 
   // 🟢 Belirli talebi getir
@@ -23,7 +31,7 @@ export class SupportTicketService {
   }
 
   // 🟢 Yeni destek talebi oluştur
-  create(data: SupportTicketCreateDto, files: File[] = []): Observable<void> {
+  create(data: SupportTicketCreateDto, files: File[] = []): Observable<SupportTicketDto> {
     const formData = new FormData();
 
     // Form alanlarını forma ekle
@@ -38,7 +46,7 @@ export class SupportTicketService {
       formData.append('attachments', file);
     });
 
-    return this.http.post<void>(this.baseUrl, formData);
+    return this.http.post<SupportTicketDto>(this.baseUrl, formData);
   }
 
   // 🟢 Talebe kullanıcı ata
@@ -63,8 +71,8 @@ export class SupportTicketService {
   }
 
   // 🟢 Talep güncelle (durum, öncelik, kategori vb.)
-  update(ticketId: number, data: any): Observable<void> {
-    return this.http.put<void>(`${this.baseUrl}/${ticketId}`, data);
+  update(ticketId: number, data: any): Observable<SupportTicketDto> {
+    return this.http.put<SupportTicketDto>(`${this.baseUrl}/${ticketId}`, data);
   }
 
   // 🔄 Atanabilir kullanıcıları getir (detay ekranı için opsiyonel)


### PR DESCRIPTION
## Summary
- add pagination/result models
- expand SupportTicketService with filtering and typed responses
- enhance ticket list with search, paging and API data
- improve ticket creation success navigation
- allow status, priority and assignment updates in ticket detail

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars rule missing)*
- `npm test --silent` *(fails: missing karma.conf.js)*

------
https://chatgpt.com/codex/tasks/task_e_688cf31a6e48832697c85b4f3e4a918a