### PR TITLE
Integrate support ticket API

### DIFF
--- a/src/app/modules/support-tickets/components/ticket-create/ticket-create.component.ts
+++ b/src/app/modules/support-tickets/components/ticket-create/ticket-create.component.ts
@@ -143,10 +143,14 @@ export class TicketCreateComponent implements OnInit {
     }
 
     this.ticketService.create(ticketData, this.attachedFiles).subscribe({
-      next: () => {
+      next: (created) => {
         this.loading = false;
         alert('✅ Destek talebi başarıyla oluşturuldu.');
-        this.router.navigate(['/support-tickets']);
+        if (created && created.id) {
+          this.router.navigate(['/support-tickets', created.id]);
+        } else {
+          this.router.navigate(['/support-tickets']);
+        }
       },
       error: (err) => {
         this.loading = false;

--- a/src/app/modules/support-tickets/components/ticket-detail/ticket-detail.component.html
+++ b/src/app/modules/support-tickets/components/ticket-detail/ticket-detail.component.html
@@ -128,6 +128,13 @@
             <option *ngFor="let p of priorityOptions" [ngValue]="p.id">{{ p.label }}</option>
           </select>
         </div>
+        <div class="col-md-6 mt-3" *ngIf="assignUsers.length">
+          <label class="form-label">Atanan Kullanıcı</label>
+          <select class="form-select" [(ngModel)]="selectedUser">
+            <option [ngValue]="null">Seçiniz</option>
+            <option *ngFor="let u of assignUsers" [ngValue]="u.id">{{ u.fullName }}</option>
+          </select>
+        </div>
       </div>
       <button class="btn btn-sm btn-primary" (click)="updateTicket()">Kaydet</button>
     </div>

--- a/src/app/modules/support-tickets/components/ticket-list/ticket-list.component.html
+++ b/src/app/modules/support-tickets/components/ticket-list/ticket-list.component.html
@@ -34,6 +34,10 @@
       <option [ngValue]="2">Orta</option>
       <option [ngValue]="3">Düşük</option>
     </select>
+
+    <div class="ms-auto">
+      <input type="text" class="form-control form-control-sm" placeholder="Ara" [(ngModel)]="searchText" (ngModelChange)="filterTickets()" />
+    </div>
   </div>
 
   <!-- Kart listesi -->
@@ -104,5 +108,10 @@
   <!-- Boş liste -->
   <div *ngIf="!loading && filteredTickets.length === 0" class="text-center text-muted mt-5">
     Seçilen kategoriye ait destek talebi bulunmamaktadır.
+  </div>
+
+  <!-- Daha fazla yükle -->
+  <div class="text-center mt-4" *ngIf="hasMore && !loading">
+    <button class="btn btn-primary" (click)="loadMore()">Daha Fazla</button>
   </div>
 </div>

--- a/src/app/modules/support-tickets/services/support-ticket.service.ts
+++ b/src/app/modules/support-tickets/services/support-ticket.service.ts
@@ -1,8 +1,23 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { SupportTicketCreateDto, SupportTicketDto } from '../models/support-ticket.model';
+
+export interface TicketQuery {
+  category?: number;
+  status?: number;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface PagedResult<T> {
+  items: T[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
 
 @Injectable({
   providedIn: 'root'
@@ -12,9 +27,26 @@ export class SupportTicketService {
 
   constructor(private http: HttpClient) {}
 
-  // 🟢 Tüm destek taleplerini getir
-  getAll(): Observable<SupportTicketDto[]> {
-    return this.http.get<SupportTicketDto[]>(this.baseUrl);
+  // 🟢 Destek taleplerini listele (filtre + sayfalı)
+  list(query: TicketQuery = {}): Observable<PagedResult<SupportTicketDto>> {
+    let params = new HttpParams();
+    if (query.category !== undefined && query.category !== null) {
+      params = params.set('category', query.category);
+    }
+    if (query.status !== undefined && query.status !== null) {
+      params = params.set('status', query.status);
+    }
+    if (query.search) {
+      params = params.set('search', query.search);
+    }
+    if (query.page) {
+      params = params.set('page', query.page);
+    }
+    if (query.pageSize) {
+      params = params.set('pageSize', query.pageSize);
+    }
+
+    return this.http.get<PagedResult<SupportTicketDto>>(this.baseUrl, { params });
   }
 
   // 🟢 Belirli talebi getir
@@ -23,7 +55,7 @@ export class SupportTicketService {
   }
 
   // 🟢 Yeni destek talebi oluştur
-  create(data: SupportTicketCreateDto, files: File[] = []): Observable<void> {
+  create(data: SupportTicketCreateDto, files: File[] = []): Observable<SupportTicketDto> {
     const formData = new FormData();
 
     // Form alanlarını forma ekle
@@ -38,7 +70,7 @@ export class SupportTicketService {
       formData.append('attachments', file);
     });
 
-    return this.http.post<void>(this.baseUrl, formData);
+    return this.http.post<SupportTicketDto>(this.baseUrl, formData);
   }
 
   // 🟢 Talebe kullanıcı ata


### PR DESCRIPTION
## Summary
- implement `SupportTicketService` with list query support and return ticket on create
- fetch paged tickets with filters in `TicketListComponent`
- enable reactive success redirect in `TicketCreateComponent`
- load assignable users and update assignments in `TicketDetailComponent`

## Testing
- `npm test` *(fails: Error in config file)*
- `npm run lint` *(fails: rule not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cf31a6e48832697c85b4f3e4a918a