### PR TITLE
feat: add admin modules for support and management

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
         "plugin:@angular-eslint/recommended",
         "plugin:@angular-eslint/template/process-inline-templates"
       ],
+      "plugins": ["@typescript-eslint"],
       "rules": {
         "@angular-eslint/directive-selector": [
           "error",

--- a/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
+++ b/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
@@ -13,26 +13,65 @@
     <span class="menu-title" translate="MENU.DASHBOARD"></span
   ></a>
 </div>
-<!-- Destek Talepleri -->
+<!-- Support -->
 <div class="menu-item menu-accordion" data-kt-menu-trigger="click">
   <span class="menu-link">
     <span class="menu-icon">
       <span [inlineSVG]="'./assets/media/icons/duotune/communication/com003.svg'" class="svg-icon svg-icon-2"></span>
     </span>
-    <span class="menu-title">Destek Talepleri</span>
+    <span class="menu-title">Support</span>
     <span class="menu-arrow"></span>
   </span>
   <div class="menu-sub menu-sub-accordion">
     <div class="menu-item">
-      <a class="menu-link" routerLink="/support-tickets" routerLinkActive="active">
-        <span class="menu-title">
-          {{ userRole === 'Admin' ? 'Tüm Talepler' : 'Taleplerim' }}
-        </span>
+      <a class="menu-link" routerLink="/support-tickets/my" routerLinkActive="active">
+        <span class="menu-title">My Tickets</span>
       </a>
     </div>
+    <div class="menu-item" *ngIf="userRole === 'Admin'">
+      <a class="menu-link" routerLink="/support-tickets/all" routerLinkActive="active">
+        <span class="menu-title">All Tickets</span>
+      </a>
+    </div>
+    <div class="menu-item" *ngIf="userRole === 'Admin'">
+      <a class="menu-link" routerLink="/support-categories" routerLinkActive="active">
+        <span class="menu-title">Support Categories</span>
+      </a>
+    </div>
+  </div>
+</div>
+
+<!-- User Management -->
+<div class="menu-item menu-accordion" data-kt-menu-trigger="click" *ngIf="userRole === 'Admin'">
+  <span class="menu-link">
+    <span class="menu-icon">
+      <span [inlineSVG]="'./assets/media/icons/duotune/communication/com006.svg'" class="svg-icon svg-icon-2"></span>
+    </span>
+    <span class="menu-title">User Management</span>
+    <span class="menu-arrow"></span>
+  </span>
+  <div class="menu-sub menu-sub-accordion">
     <div class="menu-item">
-      <a class="menu-link" routerLink="/support-tickets/create" routerLinkActive="active">
-        <span class="menu-title">Yeni Talep Oluştur</span>
+      <a class="menu-link" routerLink="/users" routerLinkActive="active">
+        <span class="menu-title">Users</span>
+      </a>
+    </div>
+  </div>
+</div>
+
+<!-- Campaigns -->
+<div class="menu-item menu-accordion" data-kt-menu-trigger="click" *ngIf="userRole === 'Admin'">
+  <span class="menu-link">
+    <span class="menu-icon">
+      <span [inlineSVG]="'./assets/media/icons/duotune/general/gen025.svg'" class="svg-icon svg-icon-2"></span>
+    </span>
+    <span class="menu-title">Campaigns</span>
+    <span class="menu-arrow"></span>
+  </span>
+  <div class="menu-sub menu-sub-accordion">
+    <div class="menu-item">
+      <a class="menu-link" routerLink="/discounts" routerLinkActive="active">
+        <span class="menu-title">Discounts</span>
       </a>
     </div>
   </div>

--- a/src/app/modules/discounts/discounts-routing.module.ts
+++ b/src/app/modules/discounts/discounts-routing.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { DiscountsComponent } from './discounts.component';
+import { AuthGuard } from '../auth/services/auth.guard';
+import { RoleGuard } from '../auth/services/role.guard';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: DiscountsComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['Admin'] }
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class DiscountsRoutingModule {}

--- a/src/app/modules/discounts/discounts.component.html
+++ b/src/app/modules/discounts/discounts.component.html
@@ -1,0 +1,32 @@
+<div class="card">
+  <div class="card-header">
+    <h3 class="card-title">Discounts</h3>
+  </div>
+  <div class="card-body" *ngIf="!loading; else loadingTpl">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Value</th>
+          <th>Status</th>
+          <th>Created By</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let d of discounts">
+          <td>{{ d.name }}</td>
+          <td>{{ d.type }}</td>
+          <td>{{ d.value }}</td>
+          <td>{{ d.status }}</td>
+          <td>{{ d.createdBy }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <ng-template #loadingTpl>
+    <div class="text-center py-10">
+      <span class="spinner-border"></span>
+    </div>
+  </ng-template>
+</div>

--- a/src/app/modules/discounts/discounts.component.ts
+++ b/src/app/modules/discounts/discounts.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { DiscountService, Discount } from './services/discount.service';
+
+@Component({
+  selector: 'app-discounts',
+  templateUrl: './discounts.component.html'
+})
+export class DiscountsComponent implements OnInit {
+  discounts: Discount[] = [];
+  loading = false;
+
+  constructor(private service: DiscountService) {}
+
+  ngOnInit(): void {
+    this.fetch();
+  }
+
+  fetch(): void {
+    this.loading = true;
+    this.service.getAll().subscribe({
+      next: (res) => {
+        this.discounts = res;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      }
+    });
+  }
+}

--- a/src/app/modules/discounts/discounts.module.ts
+++ b/src/app/modules/discounts/discounts.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DiscountsRoutingModule } from './discounts-routing.module';
+import { DiscountsComponent } from './discounts.component';
+
+@NgModule({
+  declarations: [DiscountsComponent],
+  imports: [CommonModule, FormsModule, DiscountsRoutingModule]
+})
+export class DiscountsModule {}

--- a/src/app/modules/discounts/services/discount.service.ts
+++ b/src/app/modules/discounts/services/discount.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+export interface Discount {
+  id: number;
+  name: string;
+  type: string;
+  value: number;
+  status: string | number;
+  createdBy?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class DiscountService {
+  private baseUrl = `${environment.apiUrl}/discounts`;
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<Discount[]> {
+    return this.http.get<Discount[]>(this.baseUrl);
+  }
+
+  create(data: Partial<Discount>): Observable<Discount> {
+    return this.http.post<Discount>(this.baseUrl, data);
+  }
+
+  update(id: number, data: Partial<Discount>): Observable<Discount> {
+    return this.http.put<Discount>(`${this.baseUrl}/${id}`, data);
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+}

--- a/src/app/modules/support-categories/services/support-category.service.ts
+++ b/src/app/modules/support-categories/services/support-category.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+export interface SupportCategory {
+  id: number;
+  name: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SupportCategoryService {
+  private baseUrl = `${environment.apiUrl}/support-categories`;
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<SupportCategory[]> {
+    return this.http.get<SupportCategory[]>(this.baseUrl);
+  }
+
+  create(data: Partial<SupportCategory>): Observable<SupportCategory> {
+    return this.http.post<SupportCategory>(this.baseUrl, data);
+  }
+
+  update(id: number, data: Partial<SupportCategory>): Observable<SupportCategory> {
+    return this.http.put<SupportCategory>(`${this.baseUrl}/${id}`, data);
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+}

--- a/src/app/modules/support-categories/support-categories-routing.module.ts
+++ b/src/app/modules/support-categories/support-categories-routing.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { SupportCategoriesComponent } from './support-categories.component';
+import { AuthGuard } from '../auth/services/auth.guard';
+import { RoleGuard } from '../auth/services/role.guard';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: SupportCategoriesComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['Admin'] }
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class SupportCategoriesRoutingModule {}

--- a/src/app/modules/support-categories/support-categories.component.html
+++ b/src/app/modules/support-categories/support-categories.component.html
@@ -1,0 +1,24 @@
+<div class="card">
+  <div class="card-header">
+    <h3 class="card-title">Support Categories</h3>
+  </div>
+  <div class="card-body" *ngIf="!loading; else loadingTpl">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Name</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let c of categories">
+          <td>{{ c.name }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <ng-template #loadingTpl>
+    <div class="text-center py-10">
+      <span class="spinner-border"></span>
+    </div>
+  </ng-template>
+</div>

--- a/src/app/modules/support-categories/support-categories.component.ts
+++ b/src/app/modules/support-categories/support-categories.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { SupportCategoryService, SupportCategory } from './services/support-category.service';
+
+@Component({
+  selector: 'app-support-categories',
+  templateUrl: './support-categories.component.html'
+})
+export class SupportCategoriesComponent implements OnInit {
+  categories: SupportCategory[] = [];
+  loading = false;
+
+  constructor(private service: SupportCategoryService) {}
+
+  ngOnInit(): void {
+    this.fetch();
+  }
+
+  fetch(): void {
+    this.loading = true;
+    this.service.getAll().subscribe({
+      next: (res) => {
+        this.categories = res;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      }
+    });
+  }
+}

--- a/src/app/modules/support-categories/support-categories.module.ts
+++ b/src/app/modules/support-categories/support-categories.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { SupportCategoriesRoutingModule } from './support-categories-routing.module';
+import { SupportCategoriesComponent } from './support-categories.component';
+
+@NgModule({
+  declarations: [SupportCategoriesComponent],
+  imports: [CommonModule, FormsModule, SupportCategoriesRoutingModule]
+})
+export class SupportCategoriesModule {}

--- a/src/app/modules/support-tickets/support-tickets-routing.module.ts
+++ b/src/app/modules/support-tickets/support-tickets-routing.module.ts
@@ -1,17 +1,24 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { SupportTicketsComponent } from './support-tickets.component';
 import { TicketListComponent } from './components/ticket-list/ticket-list.component';
 import { TicketCreateComponent } from './components/ticket-create/ticket-create.component';
 import { TicketDetailComponent } from './components/ticket-detail/ticket-detail.component';
 import { AuthGuard } from '../auth/services/auth.guard';
+import { RoleGuard } from '../auth/services/role.guard';
 
 const routes: Routes = [
   {
-    path: '',
+    path: 'my',
     component: TicketListComponent,
-    canActivate: [AuthGuard]
-  },           // /support-tickets
+    canActivate: [AuthGuard],
+    data: { mode: 'my' }
+  },
+  {
+    path: 'all',
+    component: TicketListComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['Admin'], mode: 'all' }
+  },
   {
     path: 'create',
     component: TicketCreateComponent,
@@ -22,7 +29,11 @@ const routes: Routes = [
     component: TicketDetailComponent,
     canActivate: [AuthGuard]
   },      // /support-tickets/:id
-  
+  {
+    path: '',
+    redirectTo: 'my',
+    pathMatch: 'full'
+  }
 ];
 
 

--- a/src/app/modules/users/services/users.service.ts
+++ b/src/app/modules/users/services/users.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+export interface AppUser {
+  id: string;
+  email: string;
+  role: string;
+  createdAt?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UsersService {
+  private baseUrl = `${environment.apiUrl}/users`;
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<AppUser[]> {
+    return this.http.get<AppUser[]>(this.baseUrl);
+  }
+
+  create(data: Partial<AppUser>): Observable<AppUser> {
+    return this.http.post<AppUser>(this.baseUrl, data);
+  }
+
+  update(id: string, data: Partial<AppUser>): Observable<AppUser> {
+    return this.http.put<AppUser>(`${this.baseUrl}/${id}`, data);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+}

--- a/src/app/modules/users/users-routing.module.ts
+++ b/src/app/modules/users/users-routing.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { UsersComponent } from './users.component';
+import { AuthGuard } from '../auth/services/auth.guard';
+import { RoleGuard } from '../auth/services/role.guard';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: UsersComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['Admin'] }
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class UsersRoutingModule {}

--- a/src/app/modules/users/users.component.html
+++ b/src/app/modules/users/users.component.html
@@ -1,0 +1,28 @@
+<div class="card">
+  <div class="card-header">
+    <h3 class="card-title">Users</h3>
+  </div>
+  <div class="card-body" *ngIf="!loading; else loadingTpl">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Email</th>
+          <th>Role</th>
+          <th>Created</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let u of users">
+          <td>{{ u.email }}</td>
+          <td>{{ u.role }}</td>
+          <td>{{ u.createdAt }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <ng-template #loadingTpl>
+    <div class="text-center py-10">
+      <span class="spinner-border"></span>
+    </div>
+  </ng-template>
+</div>

--- a/src/app/modules/users/users.component.ts
+++ b/src/app/modules/users/users.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { UsersService, AppUser } from './services/users.service';
+
+@Component({
+  selector: 'app-users',
+  templateUrl: './users.component.html'
+})
+export class UsersComponent implements OnInit {
+  users: AppUser[] = [];
+  loading = false;
+
+  constructor(private service: UsersService) {}
+
+  ngOnInit(): void {
+    this.fetch();
+  }
+
+  fetch(): void {
+    this.loading = true;
+    this.service.getAll().subscribe({
+      next: (res) => {
+        this.users = res;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      }
+    });
+  }
+}

--- a/src/app/modules/users/users.module.ts
+++ b/src/app/modules/users/users.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { UsersRoutingModule } from './users-routing.module';
+import { UsersComponent } from './users.component';
+
+@NgModule({
+  declarations: [UsersComponent],
+  imports: [CommonModule, FormsModule, UsersRoutingModule]
+})
+export class UsersModule {}

--- a/src/app/pages/routing.ts
+++ b/src/app/pages/routing.ts
@@ -84,6 +84,21 @@ const Routing: Routes = [
       import('../modules/support-tickets/support-tickets.module').then((m) => m.SupportTicketsModule),
   },
   {
+    path: 'support-categories',
+    loadChildren: () =>
+      import('../modules/support-categories/support-categories.module').then((m) => m.SupportCategoriesModule),
+  },
+  {
+    path: 'discounts',
+    loadChildren: () =>
+      import('../modules/discounts/discounts.module').then((m) => m.DiscountsModule),
+  },
+  {
+    path: 'users',
+    loadChildren: () =>
+      import('../modules/users/users.module').then((m) => m.UsersModule),
+  },
+  {
     path: '',
     redirectTo: '/dashboard',
     pathMatch: 'full',


### PR DESCRIPTION
## Summary
- add lazy-loaded modules for support categories, discounts and users
- expose my/all support ticket routes with role guard
- extend sidebar with support, user management and campaign links

## Testing
- `npm run lint`
- `npm test -- --watch=false` *(fails: Cannot find module 'karma.conf.js')*


------
https://chatgpt.com/codex/tasks/task_e_688e1129600c83268fac7843c36fff6a