### PR TITLE
feat: add pin lock screen and settings

### DIFF
--- a/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
+++ b/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
@@ -13,6 +13,21 @@
     <span class="menu-title" translate="MENU.DASHBOARD"></span
   ></a>
 </div>
+<!-- PIN Ayarları -->
+<div class="menu-item">
+  <a
+    class="menu-link without-sub"
+    routerLink="/pin-settings"
+    routerLinkActive="active"
+    ><span class="menu-icon">
+      <span
+        [inlineSVG]="'./assets/media/icons/duotune/general/gen008.svg'"
+        class="svg-icon svg-icon-2"
+      ></span>
+    </span>
+    <span class="menu-title">PIN Ayarları</span>
+  </a>
+</div>
 <!-- Support -->
 <div class="menu-item menu-accordion" data-kt-menu-trigger="click">
   <span class="menu-link">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,2 @@
 <router-outlet></router-outlet>
+<app-lock-screen *ngIf="lockService.isLocked$ | async"></app-lock-screen>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,6 +8,7 @@ import { locale as jpLang } from './modules/i18n/vocabs/jp';
 import { locale as deLang } from './modules/i18n/vocabs/de';
 import { locale as frLang } from './modules/i18n/vocabs/fr';
 import { ThemeModeService } from './_metronic/partials/layout/theme-mode-switcher/theme-mode.service';
+import { LockScreenService } from './modules/auth/services/lock-screen.service';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -19,7 +20,8 @@ import { ThemeModeService } from './_metronic/partials/layout/theme-mode-switche
 export class AppComponent implements OnInit {
   constructor(
     private translationService: TranslationService,
-    private modeService: ThemeModeService
+    private modeService: ThemeModeService,
+    public lockService: LockScreenService
   ) {
     // register translations
     this.translationService.loadTranslations(
@@ -34,5 +36,6 @@ export class AppComponent implements OnInit {
 
   ngOnInit() {
     this.modeService.init();
+    this.lockService.init();
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { AuthService } from './modules/auth/services/auth.service';
 import { AuthInterceptor } from './modules/auth/services/auth.interceptor'; // 🔥 interceptor import edildi
+import { LockScreenModule } from './modules/lock-screen/lock-screen.module';
 
 import { environment } from 'src/environments/environment';
 // #fake-start#
@@ -52,6 +53,7 @@ function appInitializer(authService: AuthService) {
     AppRoutingModule,
     InlineSVGModule.forRoot(),
     NgbModule,
+    LockScreenModule,
   ],
   providers: [
     {

--- a/src/app/modules/auth/services/lock-screen.service.ts
+++ b/src/app/modules/auth/services/lock-screen.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, tap } from 'rxjs';
+import { PinService } from './pin.service';
+import { AuthService } from './auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LockScreenService {
+  private isLockedSubject = new BehaviorSubject<boolean>(false);
+  isLocked$ = this.isLockedSubject.asObservable();
+
+  private timeoutMinutes = 5;
+  private timer: any;
+  private attempts = 0;
+
+  constructor(private pinService: PinService, private authService: AuthService) {}
+
+  init(): void {
+    this.pinService.getPinTimeout().subscribe((minutes) => {
+      this.timeoutMinutes = minutes || 5;
+      this.startListeners();
+      this.resetTimer();
+    });
+  }
+
+  private startListeners(): void {
+    ['mousemove', 'click', 'keydown'].forEach((e) =>
+      document.addEventListener(e, () => this.resetTimer())
+    );
+  }
+
+  private resetTimer(): void {
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.lock(), this.timeoutMinutes * 60 * 1000);
+  }
+
+  lock(): void {
+    this.isLockedSubject.next(true);
+  }
+
+  unlock(): void {
+    this.isLockedSubject.next(false);
+    this.attempts = 0;
+    this.resetTimer();
+  }
+
+  verifyPin(pin: string): Observable<boolean> {
+    return this.pinService.verifyPin(pin).pipe(
+      tap((success) => {
+        if (success) {
+          this.unlock();
+        } else {
+          this.attempts++;
+          if (this.attempts >= 3) {
+            this.authService.logout();
+          }
+        }
+      })
+    );
+  }
+}

--- a/src/app/modules/auth/services/pin.service.ts
+++ b/src/app/modules/auth/services/pin.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+import { environment } from '../../../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PinService {
+  private apiUrl = environment.apiUrl;
+  constructor(private http: HttpClient) {}
+
+  setPin(pin: string): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/Auth/set-pin`, { pin });
+  }
+
+  verifyPin(pin: string): Observable<boolean> {
+    return this.http
+      .post<{ success: boolean }>(`${this.apiUrl}/Auth/verify-pin`, { pin })
+      .pipe(map((res) => res.success));
+  }
+
+  getPinTimeout(): Observable<number> {
+    return this.http.get<number>(`${this.apiUrl}/AppSettings/pinTimeout`);
+  }
+}

--- a/src/app/modules/lock-screen/lock-screen.component.html
+++ b/src/app/modules/lock-screen/lock-screen.component.html
@@ -1,0 +1,24 @@
+<div class="lock-overlay">
+  <div class="lock-card">
+    <div class="text-center mb-4">
+      <img *ngIf="user?.pic" [src]="user.pic" class="avatar" alt="avatar" />
+      <div *ngIf="!user?.pic" class="avatar placeholder">{{ initials }}</div>
+      <div class="fw-bold fs-4 mt-2">{{ user?.fullName }}</div>
+    </div>
+    <form (ngSubmit)="submit()" autocomplete="off">
+      <input
+        type="password"
+        maxlength="4"
+        [(ngModel)]="pin"
+        name="pin"
+        class="form-control form-control-lg text-center mb-3"
+        inputmode="numeric"
+        pattern="[0-9]*"
+        autocomplete="off"
+        (keypress)="allowOnlyDigits($event)"
+      />
+      <div class="text-danger mb-3" *ngIf="error">{{ error }}</div>
+      <button type="submit" class="btn btn-primary w-100">Kilidi Aç</button>
+    </form>
+  </div>
+</div>

--- a/src/app/modules/lock-screen/lock-screen.component.scss
+++ b/src/app/modules/lock-screen/lock-screen.component.scss
@@ -1,0 +1,34 @@
+.lock-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1050;
+}
+
+.lock-card {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 0.475rem;
+  width: 320px;
+}
+
+.avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+}
+
+.placeholder {
+  background: #e4e6ef;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  font-size: 2rem;
+}

--- a/src/app/modules/lock-screen/lock-screen.component.ts
+++ b/src/app/modules/lock-screen/lock-screen.component.ts
@@ -1,0 +1,52 @@
+import { Component } from '@angular/core';
+import { AuthService } from '../auth/services/auth.service';
+import { LockScreenService } from '../auth/services/lock-screen.service';
+import { UserModel } from '../auth/models/user.model';
+
+@Component({
+  selector: 'app-lock-screen',
+  templateUrl: './lock-screen.component.html',
+  styleUrls: ['./lock-screen.component.scss']
+})
+export class LockScreenComponent {
+  pin = '';
+  error = '';
+  user?: UserModel;
+
+  constructor(
+    private authService: AuthService,
+    private lockService: LockScreenService
+  ) {
+    this.authService.currentUser$.subscribe(u => (this.user = u));
+  }
+
+  get initials(): string {
+    if (!this.user?.fullName) return '';
+    return this.user.fullName
+      .split(' ')
+      .map(n => n.charAt(0))
+      .join('')
+      .substring(0, 2)
+      .toUpperCase();
+  }
+
+  allowOnlyDigits(event: KeyboardEvent): void {
+    if (!/\d/.test(event.key)) {
+      event.preventDefault();
+    }
+  }
+
+  submit(): void {
+    if (this.pin.length !== 4) {
+      return;
+    }
+    this.lockService.verifyPin(this.pin).subscribe(success => {
+      if (!success) {
+        this.error = 'PIN yanlış';
+      } else {
+        this.pin = '';
+        this.error = '';
+      }
+    });
+  }
+}

--- a/src/app/modules/lock-screen/lock-screen.module.ts
+++ b/src/app/modules/lock-screen/lock-screen.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { LockScreenComponent } from './lock-screen.component';
+
+@NgModule({
+  declarations: [LockScreenComponent],
+  imports: [CommonModule, FormsModule],
+  exports: [LockScreenComponent]
+})
+export class LockScreenModule {}

--- a/src/app/modules/pin-settings/pin-settings-routing.module.ts
+++ b/src/app/modules/pin-settings/pin-settings-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { PinSettingsComponent } from './pin-settings.component';
+
+const routes: Routes = [
+  { path: '', component: PinSettingsComponent }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class PinSettingsRoutingModule {}

--- a/src/app/modules/pin-settings/pin-settings.component.html
+++ b/src/app/modules/pin-settings/pin-settings.component.html
@@ -1,0 +1,38 @@
+<div class="card">
+  <div class="card-body">
+    <h3 class="card-title mb-4">PIN Ayarları</h3>
+    <form (ngSubmit)="submit()" autocomplete="off">
+      <div class="mb-3">
+        <label class="form-label">PIN</label>
+        <input
+          type="password"
+          maxlength="4"
+          [(ngModel)]="pin"
+          name="pin"
+          class="form-control"
+          inputmode="numeric"
+          pattern="[0-9]*"
+          autocomplete="off"
+          (keypress)="allowOnlyDigits($event)"
+        />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">PIN Onayı</label>
+        <input
+          type="password"
+          maxlength="4"
+          [(ngModel)]="confirmPin"
+          name="confirmPin"
+          class="form-control"
+          inputmode="numeric"
+          pattern="[0-9]*"
+          autocomplete="off"
+          (keypress)="allowOnlyDigits($event)"
+        />
+      </div>
+      <div class="text-danger mb-3" *ngIf="error">{{ error }}</div>
+      <div class="text-success mb-3" *ngIf="message">{{ message }}</div>
+      <button type="submit" class="btn btn-primary">Kaydet</button>
+    </form>
+  </div>
+</div>

--- a/src/app/modules/pin-settings/pin-settings.component.ts
+++ b/src/app/modules/pin-settings/pin-settings.component.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { PinService } from '../auth/services/pin.service';
+
+@Component({
+  selector: 'app-pin-settings',
+  templateUrl: './pin-settings.component.html'
+})
+export class PinSettingsComponent {
+  pin = '';
+  confirmPin = '';
+  message = '';
+  error = '';
+
+  constructor(private pinService: PinService) {}
+
+  allowOnlyDigits(event: KeyboardEvent): void {
+    if (!/\d/.test(event.key)) {
+      event.preventDefault();
+    }
+  }
+
+  submit(): void {
+    this.error = '';
+    this.message = '';
+    if (this.pin.length !== 4 || this.pin !== this.confirmPin) {
+      this.error = 'PIN uyumsuz';
+      return;
+    }
+    this.pinService.setPin(this.pin).subscribe({
+      next: () => {
+        this.message = 'PIN güncellendi';
+        this.pin = '';
+        this.confirmPin = '';
+      },
+      error: () => {
+        this.error = 'PIN ayarlanamadı';
+      }
+    });
+  }
+}

--- a/src/app/modules/pin-settings/pin-settings.module.ts
+++ b/src/app/modules/pin-settings/pin-settings.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { PinSettingsRoutingModule } from './pin-settings-routing.module';
+import { PinSettingsComponent } from './pin-settings.component';
+
+@NgModule({
+  declarations: [PinSettingsComponent],
+  imports: [CommonModule, FormsModule, PinSettingsRoutingModule]
+})
+export class PinSettingsModule {}

--- a/src/app/pages/routing.ts
+++ b/src/app/pages/routing.ts
@@ -99,6 +99,13 @@ const Routing: Routes = [
       import('../modules/users/users.module').then((m) => m.UsersModule),
   },
   {
+    path: 'pin-settings',
+    loadChildren: () =>
+      import('../modules/pin-settings/pin-settings.module').then(
+        (m) => m.PinSettingsModule
+      ),
+  },
+  {
     path: '',
     redirectTo: '/dashboard',
     pathMatch: 'full',


### PR DESCRIPTION
## Summary
- add PinService for setting and verifying 4-digit lock PINs
- create full-screen lock screen and settings page
- fetch pin inactivity timeout and lock after user inactivity

## Testing
- `npm test` (fails: Cannot find module '/workspace/dekofar-hyperconnect-panel/karma.conf.js')
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e726491888326b04a04c0d9c76db2