### PR TITLE
feat: add user list page

### DIFF
--- a/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
+++ b/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
@@ -68,7 +68,7 @@
   <div class="menu-sub menu-sub-accordion">
     <div class="menu-item">
       <a class="menu-link" routerLink="/users" routerLinkActive="active">
-        <span class="menu-title">Users</span>
+        <span class="menu-title">Kullanıcılar</span>
       </a>
     </div>
   </div>

--- a/src/app/modules/users/services/users.service.ts
+++ b/src/app/modules/users/services/users.service.ts
@@ -6,8 +6,12 @@ import { environment } from 'src/environments/environment';
 export interface AppUser {
   id: string;
   email: string;
-  role: string;
-  createdAt?: string;
+  fullName: string;
+  avatar?: string;
+  roles: string[];
+  totalSales: number;
+  totalCommission: number;
+  supportTicketCount: number;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/modules/users/users.component.html
+++ b/src/app/modules/users/users.component.html
@@ -1,21 +1,40 @@
 <div class="card">
   <div class="card-header">
-    <h3 class="card-title">Users</h3>
+    <h3 class="card-title">Kullanıcılar</h3>
   </div>
   <div class="card-body" *ngIf="!loading; else loadingTpl">
-    <table class="table table-striped">
+    <table class="table table-striped align-middle">
       <thead>
         <tr>
-          <th>Email</th>
-          <th>Role</th>
-          <th>Created</th>
+          <th>Kullanıcı</th>
+          <th>Roller</th>
+          <th>Toplam Satış</th>
+          <th>Toplam Komisyon</th>
+          <th>Destek Talebi</th>
         </tr>
       </thead>
       <tbody>
         <tr *ngFor="let u of users">
-          <td>{{ u.email }}</td>
-          <td>{{ u.role }}</td>
-          <td>{{ u.createdAt }}</td>
+          <td>
+            <div class="d-flex align-items-center">
+              <div class="symbol symbol-circle symbol-40px me-3">
+                <img *ngIf="u.avatar" [src]="u.avatar" alt="avatar" />
+                <span
+                  *ngIf="!u.avatar"
+                  class="symbol-label bg-light-primary text-primary fw-bold"
+                  >{{ getInitials(u.fullName) }}</span
+                >
+              </div>
+              <div class="d-flex flex-column">
+                <span class="fw-bold">{{ u.fullName }}</span>
+                <span class="text-muted">{{ u.email }}</span>
+              </div>
+            </div>
+          </td>
+          <td>{{ u.roles.join(', ') }}</td>
+          <td>{{ u.totalSales }}</td>
+          <td>{{ u.totalCommission }}</td>
+          <td>{{ u.supportTicketCount }}</td>
         </tr>
       </tbody>
     </table>

--- a/src/app/modules/users/users.component.ts
+++ b/src/app/modules/users/users.component.ts
@@ -27,4 +27,16 @@ export class UsersComponent implements OnInit {
       }
     });
   }
+
+  getInitials(name: string): string {
+    if (!name) {
+      return '';
+    }
+    return name
+      .split(' ')
+      .filter((n) => n)
+      .map((n) => n[0])
+      .join('')
+      .toUpperCase();
+  }
 }


### PR DESCRIPTION
## Summary
- expand user interface to support roles, sales, commission and ticket counts
- display avatars or initials plus role and totals in Kullanıcılar page
- localize aside menu link to "Kullanıcılar"

## Testing
- `npm test --silent -- --watch=false` *(fails: Cannot find module 'karma.conf.js')*
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_688e74e0a5bc8326ac4cc050fca297f3