### PR TITLE
feat: add support ticket module

### DIFF
--- a/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
+++ b/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
@@ -28,29 +28,29 @@
     <span class="menu-title">PIN Ayarları</span>
   </a>
 </div>
-<!-- Support -->
+<!-- Destek Talepleri -->
 <div class="menu-item menu-accordion" data-kt-menu-trigger="click">
   <span class="menu-link">
     <span class="menu-icon">
       <span [inlineSVG]="'./assets/media/icons/duotune/communication/com003.svg'" class="svg-icon svg-icon-2"></span>
     </span>
-    <span class="menu-title">Support</span>
+    <span class="menu-title">Destek Talepleri</span>
     <span class="menu-arrow"></span>
   </span>
   <div class="menu-sub menu-sub-accordion">
     <div class="menu-item">
       <a class="menu-link" routerLink="/support-tickets/my" routerLinkActive="active">
-        <span class="menu-title">My Tickets</span>
+        <span class="menu-title">Taleplerim</span>
       </a>
     </div>
     <div class="menu-item" *ngIf="userRole === 'Admin'">
       <a class="menu-link" routerLink="/support-tickets/all" routerLinkActive="active">
-        <span class="menu-title">All Tickets</span>
+        <span class="menu-title">Tüm Talepler</span>
       </a>
     </div>
     <div class="menu-item" *ngIf="userRole === 'Admin'">
       <a class="menu-link" routerLink="/support-categories" routerLinkActive="active">
-        <span class="menu-title">Support Categories</span>
+        <span class="menu-title">Destek Kategorileri</span>
       </a>
     </div>
   </div>

--- a/src/app/modules/support-tickets/components/ticket-detail/ticket-detail.component.html
+++ b/src/app/modules/support-tickets/components/ticket-detail/ticket-detail.component.html
@@ -8,6 +8,8 @@
     <p class="text-muted">
       Oluşturulma: {{ ticket.createdAt | date:'short' }}
       <br />
+      <span *ngIf="ticket.lastReplyAt">Son Yanıt: {{ ticket.lastReplyAt | date:'short' }}</span>
+      <br />
       <span class="badge bg-info text-dark mt-2">
         {{ ticket.shopifyOrderId ? 'Shopify Siparişi Referanslı' : 'Manuel Talep' }}
       </span>
@@ -74,12 +76,12 @@
     </ul>
   </div>
 
-  <!-- Notlar -->
+  <!-- Yanıtlar -->
   <div class="mb-5" *ngIf="hasNotes()">
-    <h5 class="fw-bold mb-3">📓 Notlar</h5>
-    <div class="border rounded bg-white">
-      <div *ngFor="let note of ticket.notes" class="border-bottom p-3">
-        <div class="fw-semibold">{{ note.createdBy }}</div>
+    <h5 class="fw-bold mb-3">💬 Yanıtlar</h5>
+    <div *ngFor="let note of ticket.notes" class="mb-3 d-flex" [ngClass]="{'justify-content-end': note.createdBy === currentUserEmail}">
+      <div class="p-3 rounded w-75" [ngClass]="note.createdBy === currentUserEmail ? 'bg-primary text-white' : 'bg-light'">
+        <div class="fw-semibold small">{{ note.createdBy }}</div>
         <div class="text-muted small">{{ note.createdAt | date:'short' }}</div>
         <div class="mt-2">{{ note.message }}</div>
       </div>
@@ -142,12 +144,13 @@
 
   <!-- Not Ekle -->
   <div class="card mb-5" *ngIf="isAdmin || isSupport">
-    <div class="card-header">
-      <h5 class="card-title">Not Ekle</h5>
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <h5 class="card-title mb-0">Yanıt Yaz</h5>
+      <button *ngIf="ticket?.status !== 3" class="btn btn-sm btn-success" (click)="markResolved()">Çözüldü</button>
     </div>
     <div class="card-body">
       <textarea class="form-control" rows="3" [(ngModel)]="noteText"></textarea>
-      <button class="btn btn-sm btn-light-primary mt-2" (click)="addNote()" [disabled]="!noteText.trim()">Ekle</button>
+      <button class="btn btn-sm btn-light-primary mt-2" (click)="sendReply()" [disabled]="!noteText.trim()">Gönder</button>
     </div>
   </div>
 

--- a/src/app/modules/support-tickets/components/ticket-detail/ticket-detail.component.ts
+++ b/src/app/modules/support-tickets/components/ticket-detail/ticket-detail.component.ts
@@ -31,6 +31,7 @@ export class TicketDetailComponent implements OnInit {
   selectedUserId: string | number | null = null;
   isAdmin = false;
   isSupport = false;
+  currentUserEmail: string | null = null;
 
   constructor(
     private route: ActivatedRoute,
@@ -42,6 +43,7 @@ export class TicketDetailComponent implements OnInit {
     const current = this.auth.getAuthFromLocalStorage();
     this.isAdmin = current?.role === 'Admin';
     this.isSupport = current?.role === 'Support';
+    this.currentUserEmail = current?.email || null;
 
     this.route.paramMap.subscribe(params => {
       const id = params.get('id');
@@ -67,6 +69,7 @@ export class TicketDetailComponent implements OnInit {
         this.selectedPriority = res.priority;
         this.selectedUserId = res.assignedToUserId || null;
         this.loading = false;
+        this.ticketService.markAsRead(this.ticketId).subscribe();
       },
       error: (err) => {
         console.error('Detay çekme hatası:', err);
@@ -149,14 +152,22 @@ export class TicketDetailComponent implements OnInit {
     });
   }
 
-  addNote(): void {
+  sendReply(): void {
     if (!this.ticket || !this.noteText.trim()) return;
     this.ticketService.addNote(this.ticket.id, this.noteText).subscribe({
       next: () => {
         this.noteText = '';
         this.fetchTicketDetail();
       },
-      error: () => alert('Not eklenemedi')
+      error: () => alert('Yanıt eklenemedi')
+    });
+  }
+
+  markResolved(): void {
+    if (!this.ticket) return;
+    this.ticketService.markAsResolved(this.ticket.id).subscribe({
+      next: () => this.fetchTicketDetail(),
+      error: () => alert('Güncellenemedi')
     });
   }
 }

--- a/src/app/modules/support-tickets/components/ticket-list/ticket-list.component.html
+++ b/src/app/modules/support-tickets/components/ticket-list/ticket-list.component.html
@@ -51,9 +51,15 @@
             <!-- İçerik -->
             <div class="flex-grow-1">
               <div class="d-flex flex-wrap justify-content-between align-items-center mb-2">
-                <h5 class="mb-0">🎫 {{ ticket.subject }}</h5>
-                <span class="text-muted small">
-                  <strong>📅</strong> {{ ticket.createdAt | date:'short' }}
+                <h5 class="mb-0">
+                  🎫 {{ ticket.subject }}
+                  <span *ngIf="ticket.unreadCount && ticket.unreadCount > 0" class="badge bg-danger ms-2">
+                    {{ ticket.unreadCount }}
+                  </span>
+                </h5>
+                <span class="text-muted small d-flex flex-column text-end">
+                  <span><strong>📅</strong> {{ ticket.createdAt | date:'short' }}</span>
+                  <span *ngIf="ticket.lastReplyAt"><strong>💬</strong> {{ ticket.lastReplyAt | date:'short' }}</span>
                 </span>
               </div>
 

--- a/src/app/modules/support-tickets/models/support-ticket.model.ts
+++ b/src/app/modules/support-tickets/models/support-ticket.model.ts
@@ -74,6 +74,14 @@ export interface SupportTicketDto {
   createdBy: string;
   createdAt: string;
   status: SupportStatus;
+  /**
+   * Kullanıcıya göre okunmamış yanıt sayısı
+   */
+  unreadCount?: number;
+  /**
+   * Son yanıtın atıldığı zaman damgası
+   */
+  lastReplyAt?: string;
 
   notes: TicketNoteDto[];
   logs: TicketLogDto[];

--- a/src/app/modules/support-tickets/services/support-ticket.service.ts
+++ b/src/app/modules/support-tickets/services/support-ticket.service.ts
@@ -63,6 +63,16 @@ export class SupportTicketService {
     });
   }
 
+  // 🟢 Talebi çözüldü olarak işaretle (status=3)
+  markAsResolved(ticketId: number): Observable<void> {
+    return this.updateStatus(ticketId, 3);
+  }
+
+  // 🟢 Talebi okundu olarak işaretle
+  markAsRead(ticketId: number): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/${ticketId}/read`, {});
+  }
+
   // 🟢 Talebe not ekle
   addNote(ticketId: number, message: string): Observable<void> {
     return this.http.post<void>(`${this.baseUrl}/${ticketId}/note`, {


### PR DESCRIPTION
## Summary
- track unread replies and last reply timestamps for support tickets
- thread-style ticket detail view with reply and resolve actions
- show unread counts and last reply time in ticket list, update navigation label

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Cannot find module 'karma.conf.js')*
- `npm run lint`
- `npm run build` *(fails: Can't resolve ../../../../../environments/environment in pin.service.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688e762e56e48326998dc1e162a84d36