### PR TITLE
feat: add order tracking pages with support ticket links

### DIFF
--- a/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
+++ b/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
@@ -102,13 +102,6 @@
     <span class="menu-arrow"></span>
   </span>
   <div class="menu-sub menu-sub-accordion">
-    <!-- Tüm Siparişler -->
-    <div class="menu-item">
-      <a class="menu-link" routerLink="/orders" routerLinkActive="active">
-        <span class="menu-title">Tüm Siparişler</span>
-      </a>
-    </div>
-
     <!-- Shopify Siparişleri -->
     <div class="menu-item">
       <a

--- a/src/app/pages/orders/order.model.ts
+++ b/src/app/pages/orders/order.model.ts
@@ -1,0 +1,8 @@
+export interface OrderSummary {
+  id: number;
+  customerName: string;
+  customerId?: number;
+  total: number;
+  date: string;
+  source: 'shopify' | 'manual';
+}

--- a/src/app/pages/orders/orders.component.html
+++ b/src/app/pages/orders/orders.component.html
@@ -1,0 +1,45 @@
+<div class="card">
+  <div class="card-header pb-0">
+    <ul class="nav nav-tabs card-header-tabs">
+      <li class="nav-item">
+        <a class="nav-link" [class.active]="activeTab==='shopify'" (click)="selectTab('shopify')">Shopify Siparişleri</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" [class.active]="activeTab==='manual'" (click)="selectTab('manual')">Manuel Siparişler</a>
+      </li>
+    </ul>
+  </div>
+  <div class="card-body" *ngIf="!loading; else loadingTpl">
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Müşteri</th>
+            <th>Tutar</th>
+            <th>Tarih</th>
+            <th>Kaynak</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let o of orders">
+            <td>{{ o.id }}</td>
+            <td>
+              <a [routerLink]="['/users']" [queryParams]="{id: o.customerId}">{{ o.customerName }}</a>
+            </td>
+            <td>{{ o.total | number:'1.2-2' }} ₺</td>
+            <td>{{ o.date | date:'short' }}</td>
+            <td>{{ o.source === 'shopify' ? 'Shopify' : 'Manuel' }}</td>
+            <td>
+              <button class="btn btn-sm btn-light-primary" (click)="createTicket(o)">Destek</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <ng-template #loadingTpl>
+    <div class="card-body text-center">Yükleniyor...</div>
+  </ng-template>
+</div>

--- a/src/app/pages/orders/orders.component.scss
+++ b/src/app/pages/orders/orders.component.scss
@@ -1,0 +1,1 @@
+/* Order list page styles */

--- a/src/app/pages/orders/orders.component.ts
+++ b/src/app/pages/orders/orders.component.ts
@@ -1,0 +1,79 @@
+import { Component, OnInit } from '@angular/core';
+import { OrdersService } from './orders.service';
+import { OrderSummary } from './order.model';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'app-orders-page',
+  templateUrl: './orders.component.html',
+  styleUrls: ['./orders.component.scss']
+})
+export class OrdersComponent implements OnInit {
+  activeTab: 'shopify' | 'manual' = 'shopify';
+  shopifyOrders: OrderSummary[] = [];
+  manualOrders: OrderSummary[] = [];
+  loading = false;
+
+  constructor(
+    private service: OrdersService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.route.queryParamMap.subscribe(params => {
+      const src = params.get('source') as 'shopify' | 'manual';
+      if (src) {
+        this.activeTab = src;
+      }
+      this.loadOrders();
+    });
+  }
+
+  selectTab(tab: 'shopify' | 'manual'): void {
+    this.activeTab = tab;
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { source: tab }
+    });
+    this.loadOrders();
+  }
+
+  loadOrders(): void {
+    this.loading = true;
+    const obs = this.activeTab === 'shopify'
+      ? this.service.getShopifyOrders()
+      : this.service.getManualOrders();
+    obs.subscribe({
+      next: orders => {
+        if (this.activeTab === 'shopify') {
+          this.shopifyOrders = orders;
+        } else {
+          this.manualOrders = orders;
+        }
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      }
+    });
+  }
+
+  get orders(): OrderSummary[] {
+    return this.activeTab === 'shopify' ? this.shopifyOrders : this.manualOrders;
+  }
+
+  createTicket(order: OrderSummary): void {
+    const ticketData = {
+      subject: `ORDER-${order.id}`,
+      shopifyOrderId: order.source === 'shopify' ? String(order.id) : undefined,
+      orderSummary: {
+        orderNumber: order.id,
+        totalPrice: order.total,
+        customerName: order.customerName
+      }
+    };
+    localStorage.setItem('pendingTicket', JSON.stringify(ticketData));
+    this.router.navigate(['/support-tickets/create']);
+  }
+}

--- a/src/app/pages/orders/orders.module.ts
+++ b/src/app/pages/orders/orders.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { OrdersComponent } from './orders.component';
+
+@NgModule({
+  declarations: [OrdersComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    RouterModule.forChild([
+      { path: '', component: OrdersComponent }
+    ])
+  ]
+})
+export class OrdersPageModule {}

--- a/src/app/pages/orders/orders.service.ts
+++ b/src/app/pages/orders/orders.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { OrderSummary } from './order.model';
+
+@Injectable({ providedIn: 'root' })
+export class OrdersService {
+  private readonly SHOPIFY_URL = `${environment.apiUrl}/ShopifyOrders`;
+  private readonly MANUAL_URL = `${environment.apiUrl}/ManualOrders`;
+
+  constructor(private http: HttpClient) {}
+
+  getShopifyOrders(): Observable<OrderSummary[]> {
+    return this.http.get<OrderSummary[]>(this.SHOPIFY_URL);
+  }
+
+  getManualOrders(): Observable<OrderSummary[]> {
+    return this.http.get<OrderSummary[]>(this.MANUAL_URL);
+  }
+}

--- a/src/app/pages/routing.ts
+++ b/src/app/pages/routing.ts
@@ -71,7 +71,7 @@ const Routing: Routes = [
   {
     path: 'orders',
     loadChildren: () =>
-      import('../modules/orders/orders.module').then((m) => m.OrdersModule),
+      import('./orders/orders.module').then((m) => m.OrdersPageModule),
   },
   {
     path: 'mailbox',


### PR DESCRIPTION
## Summary
- add orders page with Shopify and manual tabs using `/ShopifyOrders` and `/ManualOrders`
- link each order to support ticket creation and user
- simplify sidebar to only Shopify and manual order links

## Testing
- `npm run lint`
- `npm test -- --watch=false` *(fails: Cannot find module karma.conf.js)*

------
https://chatgpt.com/codex/tasks/task_e_688e7a3bd6d88326824664f81847d5de