### PR TITLE
feat: add commission tracking

### DIFF
--- a/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
+++ b/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
@@ -193,6 +193,16 @@
   </div>
 </div>
 
+<!-- Komisyonlar -->
+<div class="menu-item" *ngIf="userRole === 'Admin'">
+  <a class="menu-link without-sub" routerLink="/commissions" routerLinkActive="active">
+    <span class="menu-icon">
+      <span [inlineSVG]="'./assets/media/icons/duotune/finance/fin008.svg'" class="svg-icon svg-icon-2"></span>
+    </span>
+    <span class="menu-title">Komisyonlar</span>
+  </a>
+</div>
+
 <!-- Envanter -->
 <div class="menu-item menu-accordion" data-kt-menu-trigger="click">
   <span class="menu-link">

--- a/src/app/modules/commissions/commissions-routing.module.ts
+++ b/src/app/modules/commissions/commissions-routing.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { CommissionsComponent } from './commissions.component';
+import { AuthGuard } from '../auth/services/auth.guard';
+import { RoleGuard } from '../auth/services/role.guard';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: CommissionsComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['Admin'] }
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class CommissionsRoutingModule {}

--- a/src/app/modules/commissions/commissions.component.html
+++ b/src/app/modules/commissions/commissions.component.html
@@ -1,0 +1,28 @@
+<div class="card">
+  <div class="card-header">
+    <h3 class="card-title">Komisyonlar</h3>
+  </div>
+  <div class="card-body" *ngIf="!loading; else loadingTpl">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Kullanıcı</th>
+          <th>Ay</th>
+          <th>Toplam Tutar</th>
+          <th>Toplam Komisyon</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let s of summary">
+          <td>{{ s.userName }}</td>
+          <td>{{ s.month }}</td>
+          <td>{{ s.totalAmount }}</td>
+          <td>{{ s.totalCommission }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <ng-template #loadingTpl>
+    <div class="text-center py-10"><span class="spinner-border"></span></div>
+  </ng-template>
+</div>

--- a/src/app/modules/commissions/commissions.component.ts
+++ b/src/app/modules/commissions/commissions.component.ts
@@ -1,0 +1,31 @@
+import { Component, OnInit } from '@angular/core';
+import { CommissionsService, CommissionSummary } from './services/commissions.service';
+
+@Component({
+  selector: 'app-commissions',
+  templateUrl: './commissions.component.html'
+})
+export class CommissionsComponent implements OnInit {
+  summary: CommissionSummary[] = [];
+  loading = false;
+
+  constructor(private service: CommissionsService) {}
+
+  ngOnInit(): void {
+    this.fetch();
+  }
+
+  fetch(): void {
+    this.loading = true;
+    this.service.getMonthlySummary().subscribe({
+      next: (res) => {
+        this.summary = res;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      }
+    });
+  }
+}
+

--- a/src/app/modules/commissions/commissions.module.ts
+++ b/src/app/modules/commissions/commissions.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CommissionsRoutingModule } from './commissions-routing.module';
+import { CommissionsComponent } from './commissions.component';
+
+@NgModule({
+  declarations: [CommissionsComponent],
+  imports: [CommonModule, CommissionsRoutingModule]
+})
+export class CommissionsModule {}

--- a/src/app/modules/commissions/services/commissions.service.ts
+++ b/src/app/modules/commissions/services/commissions.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+export interface Commission {
+  orderId: string;
+  amount: number;
+  percentage: number;
+  date: string;
+}
+
+export interface CommissionSummary {
+  userId: string;
+  userName: string;
+  month: string;
+  totalAmount: number;
+  totalCommission: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CommissionsService {
+  private baseUrl = `${environment.apiUrl}/Commissions`;
+
+  constructor(private http: HttpClient) {}
+
+  getByUser(): Observable<Commission[]> {
+    return this.http.get<Commission[]>(`${this.baseUrl}/by-user`);
+  }
+
+  getMonthlySummary(): Observable<CommissionSummary[]> {
+    return this.http.get<CommissionSummary[]>(`${this.baseUrl}/monthly-summary`);
+  }
+}
+

--- a/src/app/modules/profile/overview/user-profile/user-profile.component.html
+++ b/src/app/modules/profile/overview/user-profile/user-profile.component.html
@@ -41,10 +41,43 @@
         {{ u.phone }}
       </div>
 
-      <div *ngIf="u.address" class="text-gray-600">
-        <i class="bi bi-geo-alt me-2"></i>
-        {{ u.address }}
+        <div *ngIf="u.address" class="text-gray-600">
+          <i class="bi bi-geo-alt me-2"></i>
+          {{ u.address }}
+        </div>
       </div>
     </div>
   </div>
-</div>
+
+<div class="card mt-5" *ngIf="user">
+  <div class="card-header">
+    <h3 class="card-title">Komisyon Geçmişi</h3>
+  </div>
+  <div class="card-body" *ngIf="!commissionsLoading; else commissionsLoadingTpl">
+    <table class="table table-striped" *ngIf="commissions.length; else noCommissionsTpl">
+      <thead>
+        <tr>
+          <th>Sipariş ID</th>
+          <th>Tutar</th>
+          <th>Komisyon %</th>
+          <th>Tarih</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let c of commissions">
+          <td>{{ c.orderId }}</td>
+          <td>{{ c.amount }}</td>
+          <td>{{ c.percentage }}</td>
+          <td>{{ c.date | date: 'shortDate' }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <ng-template #noCommissionsTpl>
+      <div class="text-center py-10">Kayıt bulunamadı.</div>
+    </ng-template>
+  </div>
+    <ng-template #commissionsLoadingTpl>
+      <div class="text-center py-10"><span class="spinner-border"></span></div>
+    </ng-template>
+  </div>
+

--- a/src/app/modules/profile/overview/user-profile/user-profile.component.ts
+++ b/src/app/modules/profile/overview/user-profile/user-profile.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../../../auth/services/auth.service';
 import { UserModel } from '../../../auth/models/user.model';
+import { CommissionsService, Commission } from '../../../commissions/services/commissions.service';
 
 @Component({
   selector: 'app-user-profile',
@@ -9,12 +10,17 @@ import { UserModel } from '../../../auth/models/user.model';
 })
 export class UserProfileComponent implements OnInit {
   user?: UserModel;
+  commissions: Commission[] = [];
+  commissionsLoading = false;
 
-  constructor(private auth: AuthService) {}
+  constructor(private auth: AuthService, private commissionsService: CommissionsService) {}
 
   ngOnInit(): void {
-    this.auth.currentUser$.subscribe(u => {
+    this.auth.currentUser$.subscribe((u) => {
       this.user = u ?? undefined;
+      if (u) {
+        this.loadCommissions();
+      }
     });
   }
 
@@ -26,5 +32,18 @@ export class UserProfileComponent implements OnInit {
     const name = this.user.fullName ?? '';
     const parts = name.trim().split(' ');
     return parts.slice(0, 2).map(p => p.charAt(0)).join('').toUpperCase();
+  }
+
+  private loadCommissions(): void {
+    this.commissionsLoading = true;
+    this.commissionsService.getByUser().subscribe({
+      next: (res) => {
+        this.commissions = res;
+        this.commissionsLoading = false;
+      },
+      error: () => {
+        this.commissionsLoading = false;
+      },
+    });
   }
 }

--- a/src/app/pages/routing.ts
+++ b/src/app/pages/routing.ts
@@ -94,6 +94,11 @@ const Routing: Routes = [
       import('../modules/discounts/discounts.module').then((m) => m.DiscountsModule),
   },
   {
+    path: 'commissions',
+    loadChildren: () =>
+      import('../modules/commissions/commissions.module').then((m) => m.CommissionsModule),
+  },
+  {
     path: 'users',
     loadChildren: () =>
       import('../modules/users/users.module').then((m) => m.UsersModule),


### PR DESCRIPTION
## Summary
- add commissions service and admin overview
- show commission history on user profile
- add sidebar link and routing for commissions

## Testing
- `npm run lint`
- `npm test -- --watch=false` *(fails: Cannot find module 'karma.conf.js')*

------
https://chatgpt.com/codex/tasks/task_e_688e7d97fee883268509cf2ae2f4c43b