### PR TITLE
feat(profile): add user settings

### DIFF
--- a/src/app/modules/profile/profile-routing.module.ts
+++ b/src/app/modules/profile/profile-routing.module.ts
@@ -6,6 +6,7 @@ import { DocumentsComponent } from './documents/documents.component';
 import { ProjectsComponent } from './projects/projects.component';
 import { ProfileComponent } from './profile.component';
 import { ConnectionsComponent } from './connections/connections.component';
+import { ProfileSettingsComponent } from './settings/profile-settings.component';
 
 const routes: Routes = [
   {
@@ -31,6 +32,11 @@ const routes: Routes = [
       {
         path: 'connections',
         component: ConnectionsComponent,
+      },
+      {
+        path: 'settings',
+        component: ProfileSettingsComponent,
+        // Profil ayarları sayfası
       },
       { path: '', redirectTo: 'overview', pathMatch: 'full' },
       { path: '**', redirectTo: 'overview', pathMatch: 'full' },

--- a/src/app/modules/profile/profile.module.ts
+++ b/src/app/modules/profile/profile.module.ts
@@ -9,6 +9,8 @@ import { ProfileRoutingModule } from './profile-routing.module';
 import { ProfileComponent } from './profile.component';
 import { ConnectionsComponent } from './connections/connections.component';
 import { UserProfileComponent } from './overview/user-profile/user-profile.component';
+import { ProfileSettingsComponent } from './settings/profile-settings.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms'; // Form modülleri
 import {
   CardsModule,
   DropdownMenusModule,
@@ -25,6 +27,7 @@ import { SharedModule } from "../../_metronic/shared/shared.module";
     DocumentsComponent,
     ConnectionsComponent,
     UserProfileComponent,
+    ProfileSettingsComponent,
   ],
   imports: [
     CommonModule,
@@ -33,7 +36,9 @@ import { SharedModule } from "../../_metronic/shared/shared.module";
     DropdownMenusModule,
     WidgetsModule,
     CardsModule,
-    SharedModule
+    SharedModule,
+    FormsModule,
+    ReactiveFormsModule,
   ],
 })
 export class ProfileModule {}

--- a/src/app/modules/profile/services/users.service.ts
+++ b/src/app/modules/profile/services/users.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { UserModel } from '../../auth/models/user.model';
+
+// Kullanıcı işlemleri için servis
+@Injectable({ providedIn: 'root' })
+export class UsersService {
+  // API için temel adres
+  private apiUrl = `${environment.apiUrl}/users`;
+
+  constructor(private http: HttpClient) {}
+
+  // Mevcut kullanıcı bilgisini getirir
+  getMe(): Observable<UserModel> {
+    return this.http.get<UserModel>(`${this.apiUrl}/me`);
+  }
+
+  // Mevcut kullanıcı bilgisini günceller
+  updateMe(data: Partial<UserModel>): Observable<UserModel> {
+    return this.http.put<UserModel>(`${this.apiUrl}/me`, data);
+  }
+
+  // Şifre değiştirme isteği gönderir
+  changePassword(currentPassword: string, newPassword: string): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/change-password`, {
+      currentPassword,
+      newPassword,
+    });
+  }
+
+  // Profil resmini yükler
+  uploadAvatar(userId: string, file: File): Observable<{ avatarUrl: string }> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return this.http.post<{ avatarUrl: string }>(`${this.apiUrl}/${userId}/avatar`, formData);
+  }
+
+  // Profil resmini kaldırır
+  removeAvatar(userId: string): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${userId}/avatar`);
+  }
+
+  // 4 haneli PIN ayarlar
+  setPin(pin: string): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/set-pin`, { pin });
+  }
+
+  // 4 haneli PIN doğrular
+  verifyPin(pin: string): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/verify-pin`, { pin });
+  }
+}

--- a/src/app/modules/profile/settings/profile-settings.component.html
+++ b/src/app/modules/profile/settings/profile-settings.component.html
@@ -1,0 +1,90 @@
+<div class="row g-5">
+  <div class="col-lg-6">
+    <div class="card mb-5">
+      <div class="card-header">
+        <h3 class="fw-bolder">Profilim</h3>
+      </div>
+      <div class="card-body">
+        <form [formGroup]="profileForm" (ngSubmit)="saveProfile()">
+          <div class="mb-3">
+            <label class="form-label">Ad Soyad</label>
+            <input type="text" class="form-control" formControlName="fullName" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label">E-posta</label>
+            <input type="email" class="form-control" formControlName="email" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Telefon</label>
+            <input type="text" class="form-control" formControlName="phone" />
+          </div>
+          <button type="submit" class="btn btn-primary" [disabled]="profileForm.invalid">
+            Kaydet
+          </button>
+        </form>
+
+        <div class="mt-5">
+          <label class="form-label">Avatar Yükle</label>
+          <div class="d-flex align-items-center">
+            <div class="symbol symbol-100px me-5">
+              <img *ngIf="avatarPreview; else noAvatar" [src]="avatarPreview" class="img-fluid rounded" />
+              <ng-template #noAvatar>
+                <div class="symbol-label bg-secondary text-white d-flex align-items-center justify-content-center" style="width: 100px; height: 100px;">?</div>
+              </ng-template>
+            </div>
+            <div>
+              <input type="file" class="form-control mb-2" (change)="onAvatarSelected($event)" />
+              <button type="button" class="btn btn-light-danger" (click)="removeAvatar()">Avatarı Kaldır</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-lg-6">
+    <div class="card mb-5">
+      <div class="card-header">
+        <h3 class="fw-bolder">Şifreyi Değiştir</h3>
+      </div>
+      <div class="card-body">
+        <form [formGroup]="passwordForm" (ngSubmit)="changePassword()">
+          <div class="mb-3">
+            <label class="form-label">Eski Şifre</label>
+            <input type="password" class="form-control" formControlName="currentPassword" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Yeni Şifre</label>
+            <input type="password" class="form-control" formControlName="newPassword" />
+          </div>
+          <button type="submit" class="btn btn-primary" [disabled]="passwordForm.invalid">
+            Güncelle
+          </button>
+        </form>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h3 class="fw-bolder">PIN</h3>
+      </div>
+      <div class="card-body">
+        <form class="mb-4" [formGroup]="pinForm" (ngSubmit)="setPin()">
+          <div class="mb-3">
+            <label class="form-label">PIN Ayarla</label>
+            <input type="password" maxlength="4" class="form-control" formControlName="pin" />
+          </div>
+          <button type="submit" class="btn btn-primary" [disabled]="pinForm.invalid">Kaydet</button>
+        </form>
+
+        <form [formGroup]="verifyPinForm" (ngSubmit)="verifyPin()">
+          <div class="mb-3">
+            <label class="form-label">PIN Doğrula</label>
+            <input type="password" maxlength="4" class="form-control" formControlName="pin" />
+          </div>
+          <button type="submit" class="btn btn-primary" [disabled]="verifyPinForm.invalid">Doğrula</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/modules/profile/settings/profile-settings.component.ts
+++ b/src/app/modules/profile/settings/profile-settings.component.ts
@@ -1,0 +1,129 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { UsersService } from '../services/users.service';
+import { AuthService } from '../../auth/services/auth.service';
+import { UserModel } from '../../auth/models/user.model';
+
+// Profil ayarları için component
+@Component({
+  selector: 'app-profile-settings',
+  templateUrl: './profile-settings.component.html',
+})
+export class ProfileSettingsComponent implements OnInit {
+  // Profil bilgileri formu
+  profileForm: FormGroup;
+  // Şifre değişim formu
+  passwordForm: FormGroup;
+  // PIN ayarlama formu
+  pinForm: FormGroup;
+  // PIN doğrulama formu
+  verifyPinForm: FormGroup;
+  // Avatar önizleme adresi
+  avatarPreview: string | null = null;
+  // Kullanıcı kimliği
+  userId: string | null = null;
+
+  constructor(
+    private fb: FormBuilder,
+    private usersService: UsersService,
+    private authService: AuthService
+  ) {
+    // Form gruplarını oluştur
+    this.profileForm = this.fb.group({
+      fullName: ['', Validators.required],
+      email: ['', [Validators.required, Validators.email]],
+      phone: [''],
+    });
+
+    this.passwordForm = this.fb.group({
+      currentPassword: ['', Validators.required],
+      newPassword: ['', Validators.required],
+    });
+
+    this.pinForm = this.fb.group({
+      pin: ['', [Validators.required, Validators.pattern(/^[0-9]{4}$/)]],
+    });
+
+    this.verifyPinForm = this.fb.group({
+      pin: ['', [Validators.required, Validators.pattern(/^[0-9]{4}$/)]],
+    });
+  }
+
+  ngOnInit(): void {
+    // Mevcut kullanıcı bilgisini yükle
+    this.usersService.getMe().subscribe((user: UserModel) => {
+      this.userId = user.id;
+      // Gelen kullanıcı resmini önizlemeye ekle
+      this.avatarPreview = user.pic ?? null;
+      this.profileForm.patchValue({
+        fullName: user.fullName,
+        email: user.email,
+        phone: user.phone,
+      });
+    });
+  }
+
+  // Profil bilgilerini sunucuya kaydet
+  saveProfile(): void {
+    if (this.profileForm.invalid) return;
+    this.usersService.updateMe(this.profileForm.value).subscribe(() => {
+      alert('Profil güncellendi');
+      this.authService.getProfile().subscribe();
+    });
+  }
+
+  // Şifreyi sunucuya göndererek değiştir
+  changePassword(): void {
+    if (this.passwordForm.invalid) return;
+    const { currentPassword, newPassword } = this.passwordForm.value;
+    this.usersService
+      .changePassword(currentPassword, newPassword)
+      .subscribe(() => {
+        alert('Şifre değiştirildi');
+        this.passwordForm.reset();
+      });
+  }
+
+  // Yeni avatar seçildiğinde yükle ve önizlemeyi güncelle
+  onAvatarSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files && input.files[0];
+    if (!file || !this.userId) return;
+
+    const reader = new FileReader();
+    reader.onload = () => (this.avatarPreview = reader.result as string);
+    reader.readAsDataURL(file);
+
+    this.usersService.uploadAvatar(this.userId, file).subscribe((res) => {
+      this.avatarPreview = res.avatarUrl;
+      this.authService.getProfile().subscribe();
+    });
+  }
+
+  // Avatarı kaldır
+  removeAvatar(): void {
+    if (!this.userId) return;
+    this.usersService.removeAvatar(this.userId).subscribe(() => {
+      this.avatarPreview = null;
+      this.authService.getProfile().subscribe();
+    });
+  }
+
+  // PIN ayarla
+  setPin(): void {
+    if (this.pinForm.invalid) return;
+    this.usersService.setPin(this.pinForm.value.pin).subscribe(() => {
+      alert('PIN ayarlandı');
+      this.pinForm.reset();
+    });
+  }
+
+  // PIN doğrula
+  verifyPin(): void {
+    if (this.verifyPinForm.invalid) return;
+    this.usersService.verifyPin(this.verifyPinForm.value.pin).subscribe(() => {
+      alert('PIN doğrulandı');
+      this.verifyPinForm.reset();
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add user profile service with password, avatar, and PIN helpers
- create profile settings page to manage personal info and security
- wire profile module to new settings route

## Testing
- `npm test` *(fails: Error in config file - Cannot find module 'karma.conf.js')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fd6eb8b5883269fc236d51818a7e1