### PR TITLE
feat: add role, permission, and admin ip management

### DIFF
--- a/src/app/modules/permissions/permission-management.component.html
+++ b/src/app/modules/permissions/permission-management.component.html
@@ -1,0 +1,28 @@
+<div class="card">
+  <div class="card-body">
+    <div class="mb-5 d-flex align-items-center">
+      <input
+        type="number"
+        class="form-control form-control-sm w-auto me-2"
+        placeholder="Rol ID"
+        [(ngModel)]="roleId"
+      />
+      <button class="btn btn-sm btn-primary" (click)="assign()">İzin Ata</button>
+    </div>
+
+    <table class="table table-row-dashed">
+      <thead>
+        <tr>
+          <th>İzin</th>
+          <th>Seç</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let p of permissions">
+          <td>{{ p.name }}</td>
+          <td><input type="checkbox" [(ngModel)]="selected[p.name]" /></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/app/modules/permissions/permission-management.component.ts
+++ b/src/app/modules/permissions/permission-management.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+import { PermissionsService, Permission } from './services/permissions.service';
+
+// İzin yönetimi sayfası
+@Component({
+  selector: 'app-permission-management',
+  templateUrl: './permission-management.component.html'
+})
+export class PermissionManagementComponent implements OnInit {
+  permissions: Permission[] = [];
+  selected: { [key: string]: boolean } = {};
+  roleId: number | null = null;
+
+  constructor(private service: PermissionsService) {}
+
+  ngOnInit(): void {
+    this.loadPermissions();
+  }
+
+  // İzinleri API'den çeker
+  loadPermissions(): void {
+    this.service.getAllPermissions().subscribe((res) => (this.permissions = res));
+  }
+
+  // Seçili izinleri role atar
+  assign(): void {
+    if (!this.roleId) {
+      return;
+    }
+    const perms = this.permissions
+      .filter((p) => this.selected[p.name])
+      .map((p) => p.name);
+    this.service.assignPermissionsToRole(this.roleId, perms).subscribe(() => {
+      this.selected = {};
+    });
+  }
+}

--- a/src/app/modules/permissions/permissions-routing.module.ts
+++ b/src/app/modules/permissions/permissions-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { PermissionManagementComponent } from './permission-management.component';
+import { AuthGuard } from '../auth/services/auth.guard';
+import { RoleGuard } from '../auth/services/role.guard';
+
+// İzin modülü için yönlendirme
+const routes: Routes = [
+  {
+    path: '',
+    component: PermissionManagementComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['Admin'] },
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class PermissionsRoutingModule {}

--- a/src/app/modules/permissions/permissions.module.ts
+++ b/src/app/modules/permissions/permissions.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { PermissionsRoutingModule } from './permissions-routing.module';
+import { PermissionManagementComponent } from './permission-management.component';
+
+// İzin yönetim modülü
+@NgModule({
+  declarations: [PermissionManagementComponent],
+  imports: [CommonModule, FormsModule, PermissionsRoutingModule],
+})
+export class PermissionsModule {}

--- a/src/app/modules/permissions/services/permissions.service.ts
+++ b/src/app/modules/permissions/services/permissions.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+// İzin modelini temsil eder
+export interface Permission {
+  id: number;
+  name: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PermissionsService {
+  // API temel adresi
+  private baseUrl = `${environment.apiUrl}/Permissions`;
+
+  constructor(private http: HttpClient) {}
+
+  // Tüm izinleri getir
+  getAllPermissions(): Observable<Permission[]> {
+    return this.http.get<Permission[]>(this.baseUrl);
+  }
+
+  // Bir role izin ata
+  assignPermissionsToRole(roleId: number, permissions: string[]): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/assign-to-role`, {
+      roleId,
+      permissions,
+    });
+  }
+}

--- a/src/app/modules/roles/components/assign-role-modal/assign-role-modal.component.html
+++ b/src/app/modules/roles/components/assign-role-modal/assign-role-modal.component.html
@@ -1,0 +1,21 @@
+<div class="modal" tabindex="-1" [ngClass]="{ 'show d-block': visible }" *ngIf="visible">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Kullanıcıya Rol Ata</h5>
+        <button type="button" class="btn-close" (click)="close.emit()"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Kullanıcı ID</label>
+          <input [(ngModel)]="userId" type="text" class="form-control" />
+        </div>
+        <p class="mb-0">Rol: <strong>{{ roleName }}</strong></p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-light" (click)="close.emit()">Kapat</button>
+        <button type="button" class="btn btn-primary" (click)="submit()">Ata</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/modules/roles/components/assign-role-modal/assign-role-modal.component.ts
+++ b/src/app/modules/roles/components/assign-role-modal/assign-role-modal.component.ts
@@ -1,0 +1,20 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+// Kullanıcıya rol atamak için açılan modal bileşeni
+@Component({
+  selector: 'app-assign-role-modal',
+  templateUrl: './assign-role-modal.component.html',
+})
+export class AssignRoleModalComponent {
+  @Input() visible = false; // Modal görünürlüğü
+  @Input() roleName = '';
+  @Output() close = new EventEmitter<void>();
+  @Output() assign = new EventEmitter<string>();
+
+  userId = '';
+
+  // Ata butonuna basıldığında çalışır
+  submit(): void {
+    this.assign.emit(this.userId);
+  }
+}

--- a/src/app/modules/roles/role-management.component.html
+++ b/src/app/modules/roles/role-management.component.html
@@ -1,0 +1,38 @@
+<div class="card">
+  <div class="card-body">
+    <div class="mb-5">
+      <input
+        type="text"
+        class="form-control form-control-sm w-auto d-inline-block me-2"
+        placeholder="Rol Adı"
+        [(ngModel)]="newRole"
+      />
+      <button class="btn btn-sm btn-primary" (click)="addRole()">Rol Ekle</button>
+    </div>
+
+    <table class="table table-row-dashed">
+      <thead>
+        <tr>
+          <th>Rol</th>
+          <th>İşlemler</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let role of roles">
+          <td>{{ role.name }}</td>
+          <td>
+            <button class="btn btn-light-primary btn-sm" (click)="openAssignModal(role)">Kullanıcıya Rol Ata</button>
+            <button class="btn btn-light-danger btn-sm ms-2" (click)="deleteRole(role.id)">Sil</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<app-assign-role-modal
+  [visible]="modalVisible"
+  [roleName]="selectedRoleName"
+  (close)="modalVisible = false"
+  (assign)="handleAssign($event)"
+></app-assign-role-modal>

--- a/src/app/modules/roles/role-management.component.ts
+++ b/src/app/modules/roles/role-management.component.ts
@@ -1,0 +1,54 @@
+import { Component, OnInit } from '@angular/core';
+import { RolesService, Role } from './services/roles.service';
+
+// Rol yönetimi sayfası
+@Component({
+  selector: 'app-role-management',
+  templateUrl: './role-management.component.html'
+})
+export class RoleManagementComponent implements OnInit {
+  roles: Role[] = [];
+  newRole = '';
+  modalVisible = false;
+  selectedRoleName = '';
+
+  constructor(private service: RolesService) {}
+
+  ngOnInit(): void {
+    this.loadRoles();
+  }
+
+  // Rolleri API'den çeker
+  loadRoles(): void {
+    this.service.getAllRoles().subscribe((res) => (this.roles = res));
+  }
+
+  // Yeni rol ekler
+  addRole(): void {
+    if (!this.newRole) {
+      return;
+    }
+    this.service.createRole(this.newRole).subscribe(() => {
+      this.newRole = '';
+      this.loadRoles();
+    });
+  }
+
+  // Rolü siler
+  deleteRole(id: number): void {
+    this.service.deleteRole(id).subscribe(() => this.loadRoles());
+  }
+
+  // Modalı açar
+  openAssignModal(role: Role): void {
+    this.selectedRoleName = role.name;
+    this.modalVisible = true;
+  }
+
+  // Kullanıcıya rol atama işlemi
+  handleAssign(userId: string): void {
+    this.service.assignRoleToUser(userId, this.selectedRoleName).subscribe(() => {
+      this.modalVisible = false;
+    });
+  }
+}

--- a/src/app/modules/roles/roles-routing.module.ts
+++ b/src/app/modules/roles/roles-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { RoleManagementComponent } from './role-management.component';
+import { AuthGuard } from '../auth/services/auth.guard';
+import { RoleGuard } from '../auth/services/role.guard';
+
+// Rol modülü için yönlendirmeler
+const routes: Routes = [
+  {
+    path: '',
+    component: RoleManagementComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['Admin'] },
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class RolesRoutingModule {}

--- a/src/app/modules/roles/roles.module.ts
+++ b/src/app/modules/roles/roles.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RolesRoutingModule } from './roles-routing.module';
+import { RoleManagementComponent } from './role-management.component';
+import { AssignRoleModalComponent } from './components/assign-role-modal/assign-role-modal.component';
+
+// Rol yönetim modülü
+@NgModule({
+  declarations: [RoleManagementComponent, AssignRoleModalComponent],
+  imports: [CommonModule, FormsModule, RolesRoutingModule],
+})
+export class RolesModule {}

--- a/src/app/modules/roles/services/roles.service.ts
+++ b/src/app/modules/roles/services/roles.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+// Rol modelini temsil eder
+export interface Role {
+  id: number;
+  name: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RolesService {
+  // API temel adresi
+  private baseUrl = `${environment.apiUrl}/Roles`;
+
+  constructor(private http: HttpClient) {}
+
+  // Tüm rolleri getir
+  getAllRoles(): Observable<Role[]> {
+    return this.http.get<Role[]>(this.baseUrl);
+  }
+
+  // Yeni rol oluştur
+  createRole(name: string): Observable<Role> {
+    return this.http.post<Role>(this.baseUrl, { name });
+  }
+
+  // Rol sil
+  deleteRole(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+
+  // Belirli bir kullanıcıya rol ata
+  assignRoleToUser(userId: string, roleName: string): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/assign-to-user`, {
+      userId,
+      roleName,
+    });
+  }
+}

--- a/src/app/modules/settings/admin-ip/admin-ip-routing.module.ts
+++ b/src/app/modules/settings/admin-ip/admin-ip-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { AllowedIpsComponent } from './allowed-ips.component';
+import { AuthGuard } from '../../auth/services/auth.guard';
+import { RoleGuard } from '../../auth/services/role.guard';
+
+// Yetkili IP modülü için yönlendirme
+const routes: Routes = [
+  {
+    path: '',
+    component: AllowedIpsComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['Admin'] },
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class AdminIpRoutingModule {}

--- a/src/app/modules/settings/admin-ip/admin-ip.module.ts
+++ b/src/app/modules/settings/admin-ip/admin-ip.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { AdminIpRoutingModule } from './admin-ip-routing.module';
+import { AllowedIpsComponent } from './allowed-ips.component';
+
+// Yetkili IP'ler modülü
+@NgModule({
+  declarations: [AllowedIpsComponent],
+  imports: [CommonModule, FormsModule, AdminIpRoutingModule],
+})
+export class AdminIpModule {}

--- a/src/app/modules/settings/admin-ip/allowed-ips.component.html
+++ b/src/app/modules/settings/admin-ip/allowed-ips.component.html
@@ -1,0 +1,30 @@
+<div class="card">
+  <div class="card-body">
+    <div class="mb-5">
+      <input
+        type="text"
+        class="form-control form-control-sm w-auto d-inline-block me-2"
+        placeholder="IP Adresi"
+        [(ngModel)]="newIp"
+      />
+      <button class="btn btn-sm btn-primary" (click)="add()">IP Adresi Ekle</button>
+    </div>
+
+    <table class="table table-row-dashed">
+      <thead>
+        <tr>
+          <th>IP</th>
+          <th>İşlemler</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let ip of ips">
+          <td>{{ ip.ipAddress }}</td>
+          <td>
+            <button class="btn btn-light-danger btn-sm" (click)="remove(ip.id)">Sil</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/app/modules/settings/admin-ip/allowed-ips.component.ts
+++ b/src/app/modules/settings/admin-ip/allowed-ips.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { AllowedAdminIpsService, AllowedAdminIp } from './services/allowed-admin-ips.service';
+
+// Yetkili IP adreslerini yöneten bileşen
+@Component({
+  selector: 'app-allowed-ips',
+  templateUrl: './allowed-ips.component.html'
+})
+export class AllowedIpsComponent implements OnInit {
+  ips: AllowedAdminIp[] = [];
+  newIp = '';
+
+  constructor(private service: AllowedAdminIpsService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  // IP listesini yükler
+  load(): void {
+    this.service.getAll().subscribe((res) => (this.ips = res));
+  }
+
+  // Yeni IP ekler
+  add(): void {
+    if (!this.newIp) {
+      return;
+    }
+    this.service.addIp(this.newIp).subscribe(() => {
+      this.newIp = '';
+      this.load();
+    });
+  }
+
+  // IP'yi listeden kaldırır
+  remove(id: number): void {
+    this.service.removeIp(id).subscribe(() => this.load());
+  }
+}

--- a/src/app/modules/settings/admin-ip/services/allowed-admin-ips.service.ts
+++ b/src/app/modules/settings/admin-ip/services/allowed-admin-ips.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+// Yetkili IP modelini temsil eder
+export interface AllowedAdminIp {
+  id: number;
+  ipAddress: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AllowedAdminIpsService {
+  // API temel adresi
+  private baseUrl = `${environment.apiUrl}/AllowedAdminIps`;
+
+  constructor(private http: HttpClient) {}
+
+  // Tüm IP'leri getirir
+  getAll(): Observable<AllowedAdminIp[]> {
+    return this.http.get<AllowedAdminIp[]>(this.baseUrl);
+  }
+
+  // Yeni IP ekler
+  addIp(ipAddress: string): Observable<AllowedAdminIp> {
+    return this.http.post<AllowedAdminIp>(this.baseUrl, { ipAddress });
+  }
+
+  // IP'yi siler
+  removeIp(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+}

--- a/src/app/pages/routing.ts
+++ b/src/app/pages/routing.ts
@@ -104,6 +104,25 @@ const Routing: Routes = [
       import('../modules/users/users.module').then((m) => m.UsersModule),
   },
   {
+    path: 'roles',
+    loadChildren: () =>
+      import('../modules/roles/roles.module').then((m) => m.RolesModule),
+  },
+  {
+    path: 'permissions',
+    loadChildren: () =>
+      import('../modules/permissions/permissions.module').then(
+        (m) => m.PermissionsModule
+      ),
+  },
+  {
+    path: 'settings/admin-ip',
+    loadChildren: () =>
+      import('../modules/settings/admin-ip/admin-ip.module').then(
+        (m) => m.AdminIpModule
+      ),
+  },
+  {
     path: 'pin-settings',
     loadChildren: () =>
       import('../modules/pin-settings/pin-settings.module').then(


### PR DESCRIPTION
## Summary
- add role management service and component with assign role modal
- add permissions service and component for assigning permissions
- manage allowed admin IPs with new service and component
- register roles, permissions, and admin IP modules in routing

## Testing
- `npm test -- --watch=false` (fails: Cannot find module 'karma.conf.js')
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fdb5bf2488326a42b0c28cb68c2ae