### PR TITLE
feat: connect modules to navigation

### DIFF
--- a/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
+++ b/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.html
@@ -28,6 +28,34 @@
     <span class="menu-title">PIN Ayarları</span>
   </a>
 </div>
+
+<!-- Dinamik olarak oluşturulan menü bölümleri -->
+<ng-container *ngFor="let section of menuSections">
+  <div class="menu-content pt-8 pb-2">
+    <span class="menu-section text-muted text-uppercase fs-8 ls-1">
+      {{ section.header }}
+    </span>
+  </div>
+
+  <!-- Her bölümdeki menü öğelerini listele -->
+  <ng-container *ngFor="let item of section.items">
+    <div
+      class="menu-item"
+      *ngIf="(!item.roles || item.roles.includes(userRole || '')) && !(item.onlyGuests && isLoggedIn)"
+    >
+      <a
+        class="menu-link without-sub"
+        [routerLink]="item.route"
+        routerLinkActive="active"
+      >
+        <span class="menu-icon">
+          <i class="bi bi-{{ item.icon }} fs-2"></i>
+        </span>
+        <span class="menu-title">{{ item.title }}</span>
+      </a>
+    </div>
+  </ng-container>
+</ng-container>
 <!-- Destek Talepleri -->
 <div class="menu-item menu-accordion" data-kt-menu-trigger="click">
   <span class="menu-link">

--- a/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.ts
+++ b/src/app/_metronic/layout/components/aside/aside-menu/aside-menu.component.ts
@@ -2,6 +2,20 @@ import { Component, OnInit } from '@angular/core';
 import { environment } from '../../../../../../environments/environment';
 import { AuthService } from 'src/app/modules/auth';
 
+// Menü öğesi tipleri
+interface MenuItem {
+  title: string; // Türkçe başlık
+  icon: string; // Bootstrap ikon adı
+  route: string; // Yönlendirme adresi
+  roles?: string[]; // Rol bazlı görünürlük
+  onlyGuests?: boolean; // Sadece oturum açmamış kullanıcılar için
+}
+
+interface MenuSection {
+  header: string; // Grup başlığı
+  items: MenuItem[]; // Gruptaki menüler
+}
+
 @Component({
   selector: 'app-aside-menu',
   templateUrl: './aside-menu.component.html',
@@ -10,11 +24,36 @@ import { AuthService } from 'src/app/modules/auth';
 export class AsideMenuComponent implements OnInit {
   appAngularVersion: string = environment.appVersion;
   appPreviewChangelogUrl: string = environment.appPreviewChangelogUrl;
-  userRole: string | null = null;
+  userRole: string | null = null; // Oturumdaki kullanıcının rolü
+  isLoggedIn = false; // Oturum durumunu tutar
+
+  // Uygulamada tamamlanan modüller için menü yapısı
+  menuSections: MenuSection[] = [
+    {
+      header: 'Yönetim', // Yönetim modülleri
+      items: [
+        { title: 'Kullanıcılar', icon: 'person', route: '/users', roles: ['Admin'] },
+        { title: 'Roller & Yetkiler', icon: 'shield', route: '/roles', roles: ['Admin'] },
+      ],
+    },
+    {
+      header: 'Zaman Takibi', // Mesai modülü
+      items: [{ title: 'Mesai Takibi', icon: 'clock', route: '/work-sessions' }],
+    },
+    {
+      header: 'Hesabım', // Kullanıcıya özel işlemler
+      items: [
+        { title: 'Profilim', icon: 'person', route: '/profile' },
+        { title: 'Giriş Yap', icon: 'lock', route: '/auth/login', onlyGuests: true },
+      ],
+    },
+  ];
+
   constructor(private auth: AuthService) {}
 
   ngOnInit(): void {
     const user = this.auth.getAuthFromLocalStorage();
-    this.userRole = user?.role || null;
+    this.userRole = user?.role || null; // Rol bilgisini al
+    this.isLoggedIn = !!user; // Kullanıcının oturum durumunu ayarla
   }
 }

--- a/src/app/_metronic/partials/layout/extras/dropdown-inner/user-inner/user-inner.component.html
+++ b/src/app/_metronic/partials/layout/extras/dropdown-inner/user-inner/user-inner.component.html
@@ -31,19 +31,18 @@
 
   <div class="separator my-2"></div>
 
+  <!-- Profil bağlantısı -->
   <div class="menu-item px-5">
-    <a routerLink="/crafted/pages/profile" class="menu-link px-5">
-      Profilim
-    </a>
+    <a class="dropdown-item px-5" [routerLink]="['/profile']">Profilim</a>
   </div>
 
-  <div class="menu-item px-5 my-1">
-    <a routerLink="/crafted/account/settings" class="menu-link px-5">
-      Hesap Ayarları
-    </a>
+  <!-- Şifre değiştirme bağlantısı -->
+  <div class="menu-item px-5">
+    <a class="dropdown-item px-5" [routerLink]="['/profile/change-password']">Şifre Değiştir</a>
   </div>
 
+  <!-- Çıkış bağlantısı -->
   <div class="menu-item px-5">
-    <a (click)="logout()" class="menu-link px-5 cursor-pointer">Çıkış Yap</a>
+    <a class="dropdown-item px-5" [routerLink]="['/auth/logout']">Çıkış Yap</a>
   </div>
 </ng-container>

--- a/src/app/_metronic/partials/layout/extras/dropdown-inner/user-inner/user-inner.component.ts
+++ b/src/app/_metronic/partials/layout/extras/dropdown-inner/user-inner/user-inner.component.ts
@@ -20,9 +20,7 @@ export class UserInnerComponent implements OnInit, OnDestroy {
     this.user$ = this.auth.currentUser$;
   }
 
-  logout() {
-    this.auth.logout();
-  }
+  // Çıkış işlemi LogoutComponent üzerinden yapılır
 
   getInitials(firstname?: string, lastname?: string): string {
     const first = firstname?.charAt(0)?.toUpperCase() ?? '';


### PR DESCRIPTION
## Summary
- add modular navigation sections for users, roles, work sessions and profile
- expose profile actions inside user dropdown

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Cannot find module 'karma.conf.js')*
- `npm run lint`
- `npm run build` *(fails: Inlining of fonts failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fdd5804f083269e2b18b5dc804b31